### PR TITLE
fix: use filename from input

### DIFF
--- a/sops/decrypt.go
+++ b/sops/decrypt.go
@@ -17,7 +17,10 @@ func (m *Sops) DecryptSops(
 	}
 
 	workDir := "/src"
-	fileName := "encrypted.json"
+	fileName, err := encryptedFile.Name(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to get file name: %w", err)
+	}
 
 	// Mount encrypted file into container using string concatenation
 	ctr = ctr.


### PR DESCRIPTION
in the decryption process the filename is static (encrypted.json), but sops always assumes the filetype by the extension. by passing the filename through, the user can decide how their file should be handled by sops.