### PR TITLE
fix(kcl): skip post-processor for multi-document YAML output

### DIFF
--- a/kcl/run.go
+++ b/kcl/run.go
@@ -226,17 +226,33 @@ func (m *Kcl) Run(
 	// Execute and write /output.yaml
 	ctr = ctr.WithExec([]string{"sh", "-c", cmd})
 
-	// Post-process into clean YAML if formatOutput is enabled
+	// Post-process into clean YAML if formatOutput is enabled.
+	//
+	// The post-processor below is designed for KCL code whose top-level value
+	// is a list of resources (kcl emits `items:` + indented list). Modern KCL
+	// code that uses `manifests.yaml_stream(...)` already emits proper
+	// multi-document YAML, and running the post-processor on it corrupts the
+	// output (the `sed 's/^  //'` step strips two spaces from every nested
+	// line, flattening nested lists like a Dapr Component's `spec.metadata`
+	// into top-level keys, which then breaks downstream yq-based tooling).
+	//
+	// Detect multi-doc output and pass it through unchanged.
 	if formatOutput {
 		postProcess := `
-  cat /output.yaml \
-    | grep -v "^items:" \
-    | sed 's/^- /---\n/' \
-    | sed '1d' \
-    | sed 's/^  //' \
-    | sed '/^[[:space:]]*$/d' \
-    | awk 'NR==1{print "---"} 1' \
-    > /output-processed.yaml
+  if head -c 4 /output.yaml | grep -q '^---' || grep -q '^---[[:space:]]*$' /output.yaml; then
+    # kcl already produced multi-document YAML (e.g. via manifests.yaml_stream).
+    # Pass through unchanged — the sed pipeline below would corrupt it.
+    cp /output.yaml /output-processed.yaml
+  else
+    cat /output.yaml \
+      | grep -v "^items:" \
+      | sed 's/^- /---\n/' \
+      | sed '1d' \
+      | sed 's/^  //' \
+      | sed '/^[[:space:]]*$/d' \
+      | awk 'NR==1{print "---"} 1' \
+      > /output-processed.yaml
+  fi
 `
 		ctr = ctr.WithExec([]string{"sh", "-c", postProcess})
 		// Return processed output


### PR DESCRIPTION
## Summary

`RenderKustomizeBase` / `PushKustomizeBase` run KCL with `formatOutput=true`, which pipes the raw `kcl run -o` output through a fragile sed pipeline. That pipeline is designed for KCL code whose top-level value is a list rendered as `items: [...]`, but modern KCL code that uses `manifests.yaml_stream(...)` already emits proper multi-document YAML — and the post-processor corrupts it.

The specific offender is `sed 's/^  //'`, which strips two leading spaces from *every* nested line. In a Dapr `Component` this flattens `spec.metadata` (a YAML list of name/value pairs) into a top-level `metadata:` key holding an array. Downstream `split.sh` in `RenderKustomizeBase` then fails:

```
Error: cannot index array with 'name' (strconv.ParseInt: parsing "name": invalid syntax)
```

…because it does `yq eval '.metadata.name // ""'` on the mangled document.

## Fix

Detect multi-document output (file starts with `---` or contains a `---` line) and pass it through unchanged. The existing `items:`-style path is preserved verbatim for backward compatibility, so any callers relying on the old behavior are unaffected.

## Reproducer

A `deploy/main.k` that ends with `manifests.yaml_stream([...])` and includes a Dapr `Component` (with `spec.metadata` as a list) reliably triggers the error when pushed via `push-kustomize-base`. With this patch, the multi-doc output flows through untouched and `split.sh` parses every document correctly.

## Test plan

- [x] Simulated both branches locally on sample inputs:
  - multi-doc YAML → passthrough, unchanged
  - `items:`-style YAML → original sed pipeline, unchanged
- [x] Verified real `kcl run --format yaml` output from a Dapr-component-containing manifest renders 7 clean docs that yq can index via `.kind` / `.metadata.name`
- [ ] End-to-end: bump `DAGGER_KCL_MODULE` to the new release and run `dagger call -m ... push-kustomize-base` against a real KCL deploy folder

🤖 Generated with [Claude Code](https://claude.com/claude-code)