### PR TITLE
fix(kcl): rename workdir flag to subpath to avoid collision

### DIFF
--- a/kcl/README.md
+++ b/kcl/README.md
@@ -143,12 +143,12 @@ dagger call -m kcl push-kustomize-base \
   --tag latest
 ```
 
-#### Monorepos with shared KCL path deps (`--workdir`)
+#### Monorepos with shared KCL path deps (`--subpath`)
 
 When a KCL sub-package depends on a sibling module via a relative
 `path = "../..."` entry in `kcl.mod`, mount the repo root as `--source`
-and point `--workdir` at the sub-package. The container `cd`s into
-`/src/<workdir>` before running `kcl`, so deps outside the sub-package
+and point `--subpath` at the sub-package. The container `cd`s into
+`/src/<subpath>` before running `kcl`, so deps outside the sub-package
 still resolve.
 
 Layout:
@@ -177,26 +177,26 @@ Invocation from the repo root:
 # Run
 dagger call -m kcl run \
   --source . \
-  --workdir backstage-template-execution/deploy \
+  --subpath backstage-template-execution/deploy \
   export --path /tmp/rendered.yaml
 
 # Render kustomize base
 dagger call -m kcl render-kustomize-base \
   --source . \
-  --workdir backstage-template-execution/deploy \
+  --subpath backstage-template-execution/deploy \
   export --path /tmp/kustomize-base
 
 # Push kustomize base as OCI artifact
 dagger call -m kcl push-kustomize-base \
   --source . \
-  --workdir backstage-template-execution/deploy \
+  --subpath backstage-template-execution/deploy \
   --address ghcr.io/stuttgart-things/backstage-template-execution-kustomize \
   --tag v0.0.1 \
   --user env:GITHUB_USER \
   --password env:GITHUB_TOKEN
 ```
 
-Omit `--workdir` for self-contained packages — behavior is unchanged.
+Omit `--subpath` for self-contained packages — behavior is unchanged.
 
 ## Functions
 

--- a/kcl/kustomize.go
+++ b/kcl/kustomize.go
@@ -37,11 +37,11 @@ func (m *Kcl) RenderKustomizeBase(
 	// Sub-path inside source to cd into before running kcl. Enables KCL
 	// packages with relative path deps pointing outside their own directory.
 	// +optional
-	workdir string,
+	subpath string,
 ) (*dagger.Directory, error) {
 
 	// Run KCL with formatOutput=true and outputFormat="yaml" to get clean multi-doc YAML
-	renderedFile, err := m.Run(ctx, source, ociSource, parameters, parametersFile, true, "yaml", entrypoint, workdir)
+	renderedFile, err := m.Run(ctx, source, ociSource, parameters, parametersFile, true, "yaml", entrypoint, subpath)
 	if err != nil {
 		return nil, err
 	}
@@ -143,7 +143,7 @@ func (m *Kcl) PushKustomizeBase(
 	// Sub-path inside source to cd into before running kcl. Enables KCL
 	// packages with relative path deps pointing outside their own directory.
 	// +optional
-	workdir string,
+	subpath string,
 	// OCI address (e.g., ghcr.io/stuttgart-things/my-app-kustomize)
 	address string,
 	// Version tag (e.g., v1.0.0)
@@ -165,7 +165,7 @@ func (m *Kcl) PushKustomizeBase(
 ) (string, error) {
 
 	// Render the kustomize base directory
-	baseDir, err := m.RenderKustomizeBase(ctx, source, ociSource, parameters, parametersFile, entrypoint, workdir)
+	baseDir, err := m.RenderKustomizeBase(ctx, source, ociSource, parameters, parametersFile, entrypoint, subpath)
 	if err != nil {
 		return "", err
 	}

--- a/kcl/run.go
+++ b/kcl/run.go
@@ -146,9 +146,9 @@ func (m *Kcl) Run(
 	// Sub-path inside source to cd into before running kcl. Enables KCL
 	// packages with relative path deps pointing outside their own directory
 	// (e.g. shared modules in a monorepo). Pass the repo root as source and
-	// the sub-package path as workdir.
+	// the sub-package path as subpath.
 	// +optional
-	workdir string) (*dagger.File, error) {
+	subpath string) (*dagger.File, error) {
 
 	ctr := m.container()
 
@@ -164,8 +164,8 @@ func (m *Kcl) Run(
 	} else if source != nil {
 		// Mount local directory
 		ctr = ctr.WithMountedDirectory("/src", source)
-		if workdir != "" {
-			ctr = ctr.WithWorkdir("/src/" + strings.TrimPrefix(workdir, "/"))
+		if subpath != "" {
+			ctr = ctr.WithWorkdir("/src/" + strings.TrimPrefix(subpath, "/"))
 		} else {
 			ctr = ctr.WithWorkdir("/src")
 		}


### PR DESCRIPTION
## Summary
- The new `workdir` string parameter added in v0.93.0 to `Run` / `RenderKustomizeBase` / `PushKustomizeBase` collides with the pre-existing `workdir *dagger.Directory` parameter on `ConvertCrdToDirectory`.
- Dagger registers CLI flags per-module, so *any* call into `kcl` fails with `flag already exists: workdir` before dispatch.
- Renamed the new parameter to `subpath` in `run.go`, `kustomize.go`, and the README. `ConvertCrdToDirectory` is untouched (no breaking change to existing callers).

## Test plan
- [ ] `dagger call -m kcl push-kustomize-base --source . --subpath backstage-template-execution/deploy --address ghcr.io/... --tag vX.Y.Z --user env:GITHUB_USER --password env:GITHUB_TOKEN`
- [ ] `dagger call -m kcl convert-crd-to-directory --workdir . --crd-file ./my-crd.yaml` still works (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)