### PR TITLE
fix(helm): bump helmfile/polaris/kubeconform/conftest/vals

### DIFF
--- a/helm/container.go
+++ b/helm/container.go
@@ -32,7 +32,7 @@ func (m *Helm) container() *dagger.Container {
 	// ======================================================
 	// INSTALL HELMFILE
 	// ======================================================
-	helmfileVersion := "1.1.9"
+	helmfileVersion := "1.4.4"
 	helmfileBin := "helmfile"
 	helmfileTar := fmt.Sprintf("%s_%s_%s.tar.gz", helmfileBin, helmfileVersion, arch)
 	helmfileURL := fmt.Sprintf("https://github.com/helmfile/helmfile/releases/download/v%s/%s", helmfileVersion, helmfileTar)
@@ -48,7 +48,7 @@ func (m *Helm) container() *dagger.Container {
 	// ======================================================
 	// INSTALL POLARIS
 	// ======================================================
-	polarisVersion := "10.1.2"
+	polarisVersion := "10.1.8"
 	polarisTar := fmt.Sprintf("polaris_%s.tar.gz", arch)
 	polarisURL := fmt.Sprintf("https://github.com/FairwindsOps/polaris/releases/download/%s/polaris_linux_amd64.tar.gz", polarisVersion)
 	polarisBinPath := "/usr/bin/polaris"
@@ -62,7 +62,7 @@ func (m *Helm) container() *dagger.Container {
 	// ======================================================
 	// INSTALL KUBECONFORM
 	// ======================================================
-	kubeconformVersion := "0.6.7"
+	kubeconformVersion := "0.7.0"
 	kubeconformTar := "kubeconform-linux-amd64.tar.gz"
 	kubeconformURL := fmt.Sprintf("https://github.com/yannh/kubeconform/releases/download/v%s/%s", kubeconformVersion, kubeconformTar)
 	kubeconformBinPath := "/usr/bin/kubeconform"
@@ -76,7 +76,7 @@ func (m *Helm) container() *dagger.Container {
 	// ======================================================
 	// INSTALL CONFTEST
 	// ======================================================
-	conftestVersion := "0.56.0"
+	conftestVersion := "0.68.2"
 	conftestTar := fmt.Sprintf("conftest_%s_Linux_x86_64.tar.gz", conftestVersion)
 	conftestURL := fmt.Sprintf("https://github.com/open-policy-agent/conftest/releases/download/v%s/%s", conftestVersion, conftestTar)
 	conftestBinPath := "/usr/bin/conftest"
@@ -90,7 +90,7 @@ func (m *Helm) container() *dagger.Container {
 	// ======================================================
 	// INSTALL VALS
 	// ======================================================
-	valsVersion := "0.42.4"
+	valsVersion := "0.43.9"
 	valsBin := "vals"
 	valsTar := fmt.Sprintf("%s_%s_%s.tar.gz", valsBin, valsVersion, arch)
 	valsURL := fmt.Sprintf("https://github.com/helmfile/vals/releases/download/v%s/%s", valsVersion, valsTar)

--- a/tests/helm/test-policy/smoke.rego
+++ b/tests/helm/test-policy/smoke.rego
@@ -1,10 +1,12 @@
 package main
 
+import rego.v1
+
 # Smoke-test fixture for the conftest function. This policy never denies —
 # it exists only so `dagger call conftest` has a valid --policy-dir to point
 # at during `task test-helm`. Replace with real rules in downstream repos.
 
-deny[msg] {
+deny contains msg if {
 	false
 	msg := "unreachable"
 }


### PR DESCRIPTION
Step 1 of #239.

## Bumps

| Tool | From | To |
|---|---|---|
| helmfile | 1.1.9 | 1.4.4 |
| polaris | 10.1.2 | 10.1.8 |
| kubeconform | 0.6.7 | 0.7.0 |
| conftest | 0.56.0 | 0.68.2 |
| vals | 0.42.4 | 0.43.9 |

## Note: conftest breaking change handled in-tree

conftest 0.68 defaults to Rego v1, which requires `if`/`contains` keywords. The fixture `tests/helm/test-policy/smoke.rego` was rewritten:

```rego
import rego.v1

deny contains msg if {
    false
    msg := "unreachable"
}
```

Downstream consumers using their own policy directories will need to do the same migration when they rebuild against this module.

## Validation

`task test-helm` passes end-to-end (lint, render, package, push, validate-chart, kubeconform, conftest — `successes: 14`).

## Out of scope

- Helm v4 bump (tracked separately in #239 step 2 — needs its own validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)