### PR TITLE
feat(helm): bump helm to v4.1.4

### DIFF
--- a/helm/container.go
+++ b/helm/container.go
@@ -20,7 +20,7 @@ func (m *Helm) container() *dagger.Container {
 	// ======================================================
 	// INSTALL HELM (manual: Wolfi does NOT ship Helm 3.x)
 	// ======================================================
-	helmVersion := "v3.19.2"
+	helmVersion := "v4.1.4"
 
 	ctr = ctr.
 		WithExec([]string{"apk", "add", "--no-cache", "wget", "curl", "git"}).


### PR DESCRIPTION
Step 2 of #239.

## Bump

helm `v3.19.2` → `v4.1.4`

The `INSTALL HELM` block in `helm/container.go` already pulls upstream tarballs from `get.helm.sh`, so no install-script changes were needed.

## Validation

`task test-helm` passes end-to-end against the existing `tests/helm/test-chart` (which exercises a v2 Chart.yaml with a v17 redis subchart):

- lint
- render (template)
- package
- push (OCI)
- validate-chart (polaris)
- kubeconform
- conftest (`successes: 14`)

No chart-schema or flag breakage observed in the test surface.

## Caveat for downstream consumers

Helm 4 deprecated/removed a handful of v2 chart APIs and changed some flag defaults. Charts that lint clean on v3 but use long-deprecated apiVersions may need a chart-side update. The test-chart fixture is well-behaved and was not affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)