### PR TITLE
fix(helm): latent issues in push/validate/render-helmfile

### DIFF
--- a/helm/go.mod
+++ b/helm/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/Khan/genqlient v0.8.1
 	github.com/dagger/otel-go v1.43.0
-	github.com/vektah/gqlparser/v2 v2.5.32
+	github.com/vektah/gqlparser/v2 v2.5.33
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0

--- a/helm/go.sum
+++ b/helm/go.sum
@@ -37,8 +37,8 @@ github.com/sosodev/duration v1.4.0 h1:35ed0KiVFriGHHzZZJaZLgmTEEICIyt8Sx0RQfj9Ij
 github.com/sosodev/duration v1.4.0/go.mod h1:RQIBBX0+fMLc/D9+Jb/fwvVmo0eZvDDEERAikUR6SDg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/vektah/gqlparser/v2 v2.5.32 h1:k9QPJd4sEDTL+qB4ncPLflqTJ3MmjB9SrVzJrawpFSc=
-github.com/vektah/gqlparser/v2 v2.5.32/go.mod h1:c1I28gSOVNzlfc4WuDlqU7voQnsqI6OG2amkBAFmgts=
+github.com/vektah/gqlparser/v2 v2.5.33 h1:lRp8aIeNUNbimf/axZd7ETg24q06hBtPaas+TcvI/7E=
+github.com/vektah/gqlparser/v2 v2.5.33/go.mod h1:c1I28gSOVNzlfc4WuDlqU7voQnsqI6OG2amkBAFmgts=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/otel v1.43.0 h1:mYIM03dnh5zfN7HautFE4ieIig9amkNANT+xcVxAj9I=

--- a/helm/push.go
+++ b/helm/push.go
@@ -40,11 +40,13 @@ func (m *Helm) Push(
 		return "", fmt.Errorf("failed to get packaged chart filename: %w", err)
 	}
 
-	// Push the chart
+	// Push the chart. Mount src first, then overlay the packaged
+	// .tgz and the docker config — otherwise WithDirectory can
+	// clobber the .tgz that was just placed at projectDir.
 	result, err := helmContainer.
+		WithDirectory(projectDir, src).
 		WithFile(projectDir+"/"+archiveFileName, packedChart).
 		WithNewFile("/root/.docker/config.json", configJSON).
-		WithDirectory(projectDir, src).
 		WithWorkdir(projectDir).
 		WithExec([]string{
 			"helm",

--- a/helm/render.go
+++ b/helm/render.go
@@ -57,6 +57,10 @@ func (m *Helm) RenderHelmfile(
 	// +optional
 	// +default="helmfile.yaml"
 	helmfileName string,
+	// Comma-separated key=value pairs for --state-values-set
+	// (mirrors HelmfileOperation's stateValues surface).
+	// +optional
+	stateValues string,
 	// +optional
 	registrySecret *dagger.Secret,
 ) (string, error) {
@@ -78,6 +82,12 @@ func (m *Helm) RenderHelmfile(
 		"-f",
 		helmfileName,
 		"template"}
+
+	if stateValues != "" {
+		for _, pair := range splitValues(stateValues) {
+			args = append(args, "--state-values-set", pair)
+		}
+	}
 
 	renderedManifests, err := helmContainer.
 		WithExec(args).

--- a/helm/validate.go
+++ b/helm/validate.go
@@ -33,7 +33,10 @@ func (m *Helm) ValidateChart(
 		WithWorkdir("/manifests").
 		WithNewFile("rendered.yaml", renderedManifests)
 
-	// Run Polaris and capture the output
+	// Run Polaris and capture the output. Polaris is run in
+	// report-only mode: severity violations are surfaced in the
+	// returned JSON file but do not fail the call. Callers parse
+	// the report to enforce policy.
 	polarisContainer = polarisContainer.
 		WithExec([]string{
 			"polaris",
@@ -47,10 +50,6 @@ func (m *Helm) ValidateChart(
 			"--output-file",
 			"/manifests/validation.json",
 		})
-
-	if err != nil {
-		return nil, err
-	}
 
 	return polarisContainer.File("/manifests/validation.json"), nil
 }


### PR DESCRIPTION
Step 5 of #239.

## 1. push.go — reorder to avoid clobbering the chart

`WithDirectory(src, projectDir)` previously ran **after** `WithFile(...chart.tgz)` and `WithNewFile(.../config.json)`. Depending on overlay semantics that could blow away the just-placed `.tgz`. Reordered so the directory mount runs first, then the file overlays.

## 2. validate.go — drop unreachable error check, document semantics

The `if err != nil` after `WithExec(...polaris audit...)` re-checked `err` from `m.Render` (already returned on earlier nil-check). Removed.

Polaris is now explicitly documented as **report-only**: severity violations land in the returned JSON file but do not fail the call. Behavior unchanged — just describing what was already true. Callers parse the report to enforce policy.

## 3. render.go — `stateValues` on RenderHelmfile

Adds the same `stateValues` param `HelmfileOperation` already exposes:

\`\`\`bash
dagger call -m helm render-helmfile \\
  --src tests/helm/ \\
  --helmfile-name helmfile.yaml \\
  --state-values \"namespace=demo,replicas=3\"
\`\`\`

## Validation

- `task test-helm` end-to-end green (lint, render, package, push, validate-chart, kubeconform, conftest — `successes: 14`)
- Smoke-tested `render-helmfile --state-values \"namespace=demo\"` against the existing `tests/helm/helmfile.yaml` fixture — renders correctly

`go.mod` shows a `gqlparser/v2 2.5.32 → 2.5.33` patch bump from `dagger develop` (signature change required regen). `dagger.gen.go` is gitignored; CI regenerates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)