### PR TITLE
feat(helm): add Version, Test, Diff + lifecycle flags on Execute

### DIFF
--- a/helm/container.go
+++ b/helm/container.go
@@ -15,7 +15,7 @@ func (m *Helm) container() *dagger.Container {
 
 	ctr := dag.Container().
 		From(m.BaseImage).
-		WithExec([]string{"apk", "add", "--no-cache", "wget", "curl", "git", "kubectl-1.35"})
+		WithExec([]string{"apk", "add", "--no-cache", "wget", "curl", "git", "kubectl-1.35", "kubectl-1.35-default"})
 
 	// ======================================================
 	// INSTALL HELM (manual: Wolfi does NOT ship Helm 3.x/4.x)

--- a/helm/diff.go
+++ b/helm/diff.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"context"
+	"dagger/helm/internal/dagger"
+)
+
+// Diff runs `helmfile diff` against the cluster pointed to by
+// kubeConfig, showing what would change for the releases declared
+// in the helmfile. Read-only; does not apply changes.
+func (m *Helm) Diff(
+	ctx context.Context,
+	// +optional
+	src *dagger.Directory,
+	// +optional
+	// +default="helmfile.yaml"
+	helmfileRef string,
+	// Comma-separated key=value pairs for --state-values-set
+	// +optional
+	stateValues string,
+	// +optional
+	registrySecret *dagger.Secret,
+	kubeConfig *dagger.Secret,
+) (string, error) {
+
+	projectDir := "/helmfiles"
+	dockerConfigPath := "/root/.docker/config.json"
+	kubeConfigPath := "/root/.kube/config"
+
+	helmContainer := m.container().
+		WithEnvVariable("HELMFILE_INTERACTIVE", "false")
+
+	if src != nil {
+		helmContainer = helmContainer.
+			WithDirectory(projectDir, src).
+			WithWorkdir(projectDir)
+	} else {
+		helmContainer = helmContainer.
+			WithExec([]string{"mkdir", "-p", projectDir}).
+			WithWorkdir(projectDir)
+	}
+
+	if registrySecret != nil { // pragma: allowlist secret
+		helmContainer = helmContainer.WithMountedSecret(dockerConfigPath, registrySecret)
+	}
+
+	helmContainer = helmContainer.WithMountedSecret(kubeConfigPath, kubeConfig)
+
+	args := []string{"helmfile", "-f", helmfileRef, "diff"}
+	if stateValues != "" {
+		for _, pair := range splitValues(stateValues) {
+			args = append(args, "--state-values-set", pair)
+		}
+	}
+
+	return helmContainer.WithExec(args).Stdout(ctx)
+}

--- a/helm/execute.go
+++ b/helm/execute.go
@@ -36,6 +36,19 @@ func (m *Helm) Execute(
 	// Chart version (e.g., "1.2.3")
 	// +optional
 	version string,
+	// Wait for resources to be ready (--wait)
+	// +optional
+	wait bool,
+	// Timeout for --wait, e.g. "5m", "300s" (--timeout)
+	// +optional
+	timeout string,
+	// Roll back the release if the install/upgrade fails (--atomic)
+	// +optional
+	atomic bool,
+	// Render templates and validate against the cluster but do not
+	// apply changes (--dry-run)
+	// +optional
+	dryRun bool,
 ) error {
 
 	projectDir := "/helm"
@@ -93,6 +106,20 @@ func (m *Helm) Execute(
 			for _, pair := range valuePairs {
 				args = append(args, "--set", pair)
 			}
+		}
+
+		// LIFECYCLE FLAGS
+		if wait {
+			args = append(args, "--wait")
+		}
+		if timeout != "" {
+			args = append(args, "--timeout", timeout)
+		}
+		if atomic {
+			args = append(args, "--atomic")
+		}
+		if dryRun {
+			args = append(args, "--dry-run")
 		}
 
 	case "uninstall":

--- a/helm/test.go
+++ b/helm/test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"context"
+	"dagger/helm/internal/dagger"
+)
+
+// Test runs `helm test <release>` against an existing release.
+// Requires a kubeconfig pointing at the cluster the release lives in.
+func (m *Helm) Test(
+	ctx context.Context,
+	releaseName string,
+	namespace string,
+	kubeConfig *dagger.Secret,
+	// +optional
+	// Container timeout for the test pods (e.g. "5m", "300s")
+	timeout string,
+	// +optional
+	// Show pod logs even on success
+	logs bool,
+) (string, error) {
+
+	args := []string{"helm", "test", releaseName, "--namespace", namespace}
+	if timeout != "" {
+		args = append(args, "--timeout", timeout)
+	}
+	if logs {
+		args = append(args, "--logs")
+	}
+
+	return m.container().
+		WithMountedSecret("/root/.kube/config", kubeConfig).
+		WithExec(args).
+		Stdout(ctx)
+}

--- a/helm/version.go
+++ b/helm/version.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"context"
+)
+
+// Version returns the versions of every binary baked into the helm
+// container (helm, helmfile, polaris, kubeconform, conftest, vals,
+// kubectl). Useful for debugging behavior drift between module
+// releases.
+func (m *Helm) Version(ctx context.Context) (string, error) {
+	script := `
+set -e
+echo "=== helm ==="        && helm version --short
+echo "=== helmfile ==="    && helmfile --version
+echo "=== polaris ==="     && polaris version
+echo "=== kubeconform ===" && kubeconform -v
+echo "=== conftest ==="    && conftest --version | head -1
+echo "=== vals ==="        && vals version
+echo "=== kubectl ==="     && kubectl version --client 2>&1 | head -2
+`
+	return m.container().
+		WithExec([]string{"sh", "-c", script}).
+		Stdout(ctx)
+}


### PR DESCRIPTION
Step 6 of #239.

## New functions

### `Version()` — debugging aid
Reports every bundled binary in one call. No args.

\`\`\`bash
dagger call -m helm version
\`\`\`
\`\`\`
=== helm ===        v4.1.4+g05fa379
=== helmfile ===    helmfile version 1.4.4
=== polaris ===     Polaris version:10.1.8
=== kubeconform === v0.7.0
=== conftest ===    Conftest: 0.68.2
=== vals ===        Version: 0.43.9
=== kubectl ===     Client Version: v1.35.4
                    Kustomize Version: v5.7.1
\`\`\`

### `Test()` — post-install verification
Wraps `helm test <release>`. Requires kubeconfig.

\`\`\`bash
dagger call -m helm test \\
  --release-name nginx \\
  --namespace default \\
  --kube-config file://~/.kube/config \\
  --timeout 5m --logs
\`\`\`

### `Diff()` — read-only release comparison
Wraps `helmfile diff`. Requires kubeconfig.

\`\`\`bash
dagger call -m helm diff \\
  --src tests/helm/ \\
  --helmfile-ref helmfile.yaml \\
  --kube-config file://~/.kube/config
\`\`\`

### `Execute()` — lifecycle flags
Adds `--wait`, `--timeout`, `--atomic`, `--dry-run`.

\`\`\`bash
dagger call -m helm execute \\
  --release-name nginx --chart-path oci://... \\
  --namespace default --kube-config file://~/.kube/config \\
  --wait --timeout 5m --atomic
\`\`\`

## Drive-by fix

`Version()` exposed that PR #242 (kubectl pin) left `/usr/bin/kubectl` missing — the versioned `kubectl-1.35` Wolfi package needs its `kubectl-1.35-default` companion to publish the unsuffixed binary. Added. None of `task test-helm` exercises kubectl, so the regression slipped through.

## Validation

- `dagger call version` → all 7 binaries report cleanly
- `task test-helm` end-to-end green (`successes: 14`)
- `Test()` and `Diff()` signatures only — both need a real cluster to validate beyond signature

🤖 Generated with [Claude Code](https://claude.com/claude-code)