### PR TITLE
test(helm): wire version + render-helmfile, refresh fixture

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -533,6 +533,10 @@ tasks:
     cmds:
       - |
         dagger call -m {{ .MODULE }} \
+        version \
+        -vv --progress plain
+      - |
+        dagger call -m {{ .MODULE }} \
         lint \
         --src {{ .TEST_CHART }} \
         -vv --progress plain
@@ -541,6 +545,12 @@ tasks:
         render \
         --src {{ .TEST_CHART }} \
         --valuesFile {{ .TEST_VALUES }} \
+        -vv --progress plain
+      - |
+        dagger call -m {{ .MODULE }} \
+        render-helmfile \
+        --src {{ .TEST_HELMFILE_DIR }} \
+        --helmfile-name helmfile.yaml \
         -vv --progress plain
       - |
         dagger call -m {{ .MODULE }} \
@@ -588,6 +598,7 @@ tasks:
     vars:
       MODULE: helm
       TEST_CHART: tests/{{ .MODULE }}/test-chart/
+      TEST_HELMFILE_DIR: tests/{{ .MODULE }}/
       TEST_PACKAGE: tests/{{ .MODULE }}/chart.tgz
       TEST_VALUES: tests/{{ .MODULE }}/test-values.yaml
       TEST_POLICY: tests/{{ .MODULE }}/test-policy/

--- a/tests/helm/helmfile.yaml
+++ b/tests/helm/helmfile.yaml
@@ -6,7 +6,7 @@ releases:
   - name: postgresserver
     namespace: test2
     chart: bitnami/postgresql
-    version: 16.7.18
+    version: 18.6.2
     createNamespace: true
     values:
       - postgresqlPassword: supersecurepassword # pragma: allowlist secret


### PR DESCRIPTION
Step 7 of #239.

## Taskfile additions

Two new steps in `task test-helm`:

- **`version`** (prepended) — sanity-check the bundled binaries every run
- **`render-helmfile`** — uses the existing `tests/helm/helmfile.yaml` fixture (which was sitting unused)

## Fixture refresh

`tests/helm/helmfile.yaml`: bump `bitnami/postgresql` from `16.7.18` → `18.6.2`.

The 16.x line is no longer in the public bitnami index (and 17.x was skipped upstream). 18.6.2 is the current published chart.

## Coverage now

`task test-helm` runs **9 functions** (was 7):

```
version  ← new
lint
render
render-helmfile  ← new
package
push
validate-chart
kubeconform
conftest
```

`Test()`, `Diff()`, `HelmfileOperation`, and `Execute` still skipped — they all need a real cluster.

## Validation

`task test-helm` exits 0 end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)