### PR TITLE
docs(helm): polish README (versions table, render-helmfile, etc.)

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -7,11 +7,28 @@ This module provides Dagger functions for Helm chart operations including lintin
 - ✅ Helm chart linting and validation
 - ✅ Chart packaging and registry publishing
 - ✅ Template rendering with custom values
-- ✅ Helmfile operations with Kubernetes integration
-- ✅ Polaris-based security validation
-- ✅ Kubeconform schema validation (with Datree CRDs-catalog fallback)
+- ✅ Helmfile operations (apply / destroy / template / diff) with Kubernetes integration
+- ✅ Polaris-based security validation (report-only)
+- ✅ Kubeconform schema validation (with the community-maintained CRDs-catalog at `github.com/datreeio/CRDs-catalog` as fallback)
 - ✅ Conftest / OPA policy evaluation (scaffold; policies caller-supplied)
 - ✅ Registry authentication and multi-registry support
+- ✅ Vault-backed kubeconfig retrieval via vals
+- ✅ `helm test` post-install verification
+- ✅ Bundled tool-version reporting (`version`)
+
+## Bundled tool versions
+
+Pinned in `helm/container.go`. Run `dagger call -m helm version` to report the live values from a built container.
+
+| Tool        | Version |
+|-------------|---------|
+| helm        | v4.1.4  |
+| helmfile    | 1.4.4   |
+| polaris     | 10.1.8  |
+| kubeconform | 0.7.0   |
+| conftest    | 0.68.2  |
+| vals        | 0.43.9  |
+| kubectl     | 1.35.x (Wolfi `kubectl-1.35`) |
 
 ## Prerequisites
 
@@ -40,7 +57,7 @@ dagger call -m helm package \
   export --path=/tmp/chart.tgz
 ```
 
-### INSTALL CHART
+### Install Chart
 
 ```bash
 dagger call -m helm execute \
@@ -50,8 +67,11 @@ dagger call -m helm execute \
 --operation install \
 --namespace default \
 --values "service.type=ClusterIP" \
+--wait --timeout 5m --atomic \
 --kube-config file://~/.kube/demo-infra
 ```
+
+`--wait` blocks until resources are Ready, `--timeout` bounds the wait, and `--atomic` rolls back on failure. `--dry-run` is also available for render-and-validate-only.
 
 ```bash
 dagger call -m helm execute \
@@ -120,6 +140,23 @@ dagger call -m helm push \
   --password env:GITHUB_TOKEN
 ```
 
+### Render Helmfile
+
+Renders all releases declared in a helmfile to YAML without contacting a cluster. Useful for diffs against a checked-in golden manifest.
+
+```bash
+# Render local helmfile
+dagger call -m helm render-helmfile \
+  --src tests/helm/ \
+  --helmfile-name helmfile.yaml
+
+# Render with state-values overrides
+dagger call -m helm render-helmfile \
+  --src tests/helm/ \
+  --helmfile-name helmfile.yaml \
+  --state-values "namespace=demo,replicas=3"
+```
+
 ### Helmfile Operations
 
 ```bash
@@ -147,6 +184,38 @@ dagger call -m helm helmfile-operation \
   --progress plain
 ```
 
+### Helmfile Diff
+
+Read-only comparison of declared releases against the cluster. Wraps `helmfile diff`.
+
+```bash
+dagger call -m helm diff \
+  --src tests/helm/ \
+  --helmfile-ref helmfile.yaml \
+  --kube-config file://~/.kube/config
+```
+
+### Helm Test
+
+Post-install verification — runs `helm test <release>` against an existing release.
+
+```bash
+dagger call -m helm test \
+  --release-name nginx \
+  --namespace default \
+  --kube-config file://~/.kube/config \
+  --timeout 5m \
+  --logs
+```
+
+### Bundled Tool Versions
+
+Print the version of every binary in the container. No args.
+
+```bash
+dagger call -m helm version
+```
+
 ### Vault Integration
 
 ```bash
@@ -163,6 +232,8 @@ dagger call -m helm helmfile-operation \
 
 ### Security Validation
 
+Polaris runs in **report-only** mode — severity violations land in the returned JSON file but do not fail the call. Callers parse the report to enforce policy.
+
 ```bash
 # Validate with Polaris
 dagger call -m helm validate-chart \
@@ -174,11 +245,13 @@ dagger call -m helm validate-chart \
 ### Schema Validation (Kubeconform)
 
 Render the chart and validate every resource against Kubernetes + CRD schemas.
-Defaults to upstream Kubernetes schemas plus the Datree CRDs-catalog fallback,
-which covers ArgoCD, Gateway-API, cert-manager, and cilium CRDs.
+Defaults to upstream Kubernetes schemas plus the community-maintained
+[CRDs-catalog](https://github.com/datreeio/CRDs-catalog) at
+`github.com/datreeio/CRDs-catalog`, which covers ArgoCD, Gateway-API,
+cert-manager, and cilium CRDs.
 
 ```bash
-# Default schema locations (k8s + Datree CRDs-catalog)
+# Default schema locations (k8s + CRDs-catalog)
 dagger call -m helm kubeconform \
   --src tests/helm/test-chart
 
@@ -199,6 +272,11 @@ dagger call -m helm kubeconform \
 Render the chart and run `conftest test` against a caller-supplied Rego policy
 directory. Policy authoring is deferred; the function is scaffolded so consumers
 can wire the call now and add policies later without a signature change.
+
+> **Rego v1 required.** The bundled conftest 0.68.x defaults to Rego v1, which
+> requires the `if` and `contains` keywords. Old-style policies fail to parse —
+> add `import rego.v1` and rewrite rules to `deny contains msg if { ... }`.
+> See `tests/helm/test-policy/smoke.rego` for a minimal example.
 
 ```bash
 dagger call -m helm conftest \
@@ -222,3 +300,7 @@ task test-helm
 - [Helm Documentation](https://helm.sh/docs/)
 - [Helmfile](https://helmfile.readthedocs.io/)
 - [Polaris](https://polaris.docs.fairwinds.com/)
+- [Kubeconform](https://github.com/yannh/kubeconform)
+- [Conftest](https://www.conftest.dev/)
+- [vals](https://github.com/helmfile/vals)
+- [CRDs-catalog](https://github.com/datreeio/CRDs-catalog)


### PR DESCRIPTION
Step 8 (final) of #239.

## Changes

- **Bundled tool versions table** — front-and-center so consumers don't have to read `helm/container.go` to know which helm/helmfile/polaris/etc. they get.
- **Title-case fix** — `INSTALL CHART` → `Install Chart` (matches every other heading).
- **Datree wording** — Datree (the company) shut down in 2024. Repo is now community-maintained at `github.com/datreeio/CRDs-catalog`. Inline comment in code block also updated.
- **New API sections**: `render-helmfile`, `diff`, `test`, `version` — all four landed in earlier PRs but were undocumented.
- **Quick-Start install** updated to demonstrate the new `--wait` / `--timeout` / `--atomic` flags from PR #245.
- **Polaris** documented as report-only (matches behavior locked in by PR #244).
- **Rego v1** notice on the Conftest section so downstream policy authors know the conftest 0.68 bump means they need `import rego.v1` + new keyword forms. Points at `tests/helm/test-policy/smoke.rego` as a minimal example.
- **Resources** expanded with kubeconform / conftest / vals / CRDs-catalog links.

## Out of scope

This is documentation only — no code changes, so `task test-helm` was not re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)