### PR TITLE
feat(kcl): add render-install-yaml for one-shot kubectl apply

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -254,6 +254,18 @@ tasks:
         export --path={{ .OUTPUT_KUSTOMIZE_DIR }}
         echo "Generated kustomize base:"
         ls {{ .OUTPUT_KUSTOMIZE_DIR }}/
+      - |
+        echo "Testing install.yaml rendering..."
+        dagger call -m {{ .MODULE }} \
+        render-install-yaml \
+        --source {{ .TEST_KUSTOMIZE_PROJECT }} \
+        --parameters-file {{ .TEST_KUSTOMIZE_PARAMS }} \
+        --progress plain \
+        export --path={{ .OUTPUT_INSTALL_YAML }}
+        echo "Generated install.yaml:"
+        ls -la {{ .OUTPUT_INSTALL_YAML }}
+        # sanity-check: must contain at least one kind: line
+        grep -q '^kind:' {{ .OUTPUT_INSTALL_YAML }}
     vars:
       MODULE: kcl
       TEST_KCL_PROJECT: tests/kcl/test-kcl-project
@@ -263,6 +275,7 @@ tasks:
       TEST_KUSTOMIZE_PROJECT: tests/kcl/test-kustomize-project
       TEST_KUSTOMIZE_PARAMS: tests/kcl/test-kustomize-project/params.yaml
       OUTPUT_KUSTOMIZE_DIR: /tmp/dagger/kcl-test-kustomize-base
+      OUTPUT_INSTALL_YAML: /tmp/dagger/kcl-test-install.yaml
 
   test-kcl-kustomize:
     desc: Test KCL kustomize base rendering
@@ -299,6 +312,36 @@ tasks:
       TEST_KUSTOMIZE_PROJECT: tests/kcl/test-kustomize-project
       TEST_KUSTOMIZE_PARAMS: tests/kcl/test-kustomize-project/params.yaml
       OUTPUT_KUSTOMIZE_DIR: /tmp/dagger/kcl-test-kustomize-base
+
+  test-kcl-install-yaml:
+    desc: Test KCL render-install-yaml (KCL → kustomize → flat install.yaml)
+    cmds:
+      - |
+        echo "Rendering install.yaml from KCL source..."
+        dagger call -m {{ .MODULE }} \
+        render-install-yaml \
+        --source {{ .TEST_KUSTOMIZE_PROJECT }} \
+        --parameters-file {{ .TEST_KUSTOMIZE_PARAMS }} \
+        --progress plain \
+        export --path={{ .OUTPUT_INSTALL_YAML }}
+
+        echo ""
+        echo "Generated install.yaml:"
+        ls -la {{ .OUTPUT_INSTALL_YAML }}
+
+        echo ""
+        echo "--- install.yaml ---"
+        cat {{ .OUTPUT_INSTALL_YAML }}
+
+        echo ""
+        echo "Sanity check: must contain at least one 'kind:' line"
+        grep -q '^kind:' {{ .OUTPUT_INSTALL_YAML }}
+        echo "OK"
+    vars:
+      MODULE: kcl
+      TEST_KUSTOMIZE_PROJECT: tests/kcl/test-kustomize-project
+      TEST_KUSTOMIZE_PARAMS: tests/kcl/test-kustomize-project/params.yaml
+      OUTPUT_INSTALL_YAML: /tmp/dagger/kcl-test-install.yaml
 
   render-kustomize-base:
     desc: Render kustomize base from KCL source

--- a/kcl/README.md
+++ b/kcl/README.md
@@ -159,6 +159,27 @@ dagger call -m kcl push-kustomize-base \
   --tag latest
 ```
 
+#### One-shot `install.yaml` for `kubectl apply -f`
+
+`render-install-yaml` runs `render-kustomize-base` and then `kustomize build`
+against the result, producing a single flat multi-doc YAML file. Attach it to
+a GitHub release so users can run `kubectl apply -f <release-url>/install.yaml`
+without learning kustomize or pulling an OCI artifact.
+
+```bash
+dagger call -m kcl render-install-yaml \
+  --source ./deployment \
+  --parameters-file ./tests/kcl-deploy-profile.yaml \
+  export --path=/tmp/install.yaml
+
+# Pin a specific kustomize version (default: v5.4.3)
+dagger call -m kcl render-install-yaml \
+  --source ./deployment \
+  --parameters-file ./tests/kcl-deploy-profile.yaml \
+  --kustomize-version v5.5.0 \
+  export --path=/tmp/install.yaml
+```
+
 #### Monorepos with shared KCL path deps (`--subpath`)
 
 When a KCL sub-package depends on a sibling module via a relative
@@ -232,6 +253,7 @@ Omit `--subpath` for self-contained packages — behavior is unchanged.
 |---------------------------|--------------------------------------|--------------------------------------------|--------------------------|
 | `RenderKustomizeBase()`   | Render KCL output into a kustomize base directory | `source?`, `ociSource?`, `parameters?`, `parametersFile?`, `entrypoint?` | Directory with split YAML files + `kustomization.yaml` |
 | `PushKustomizeBase()`     | Render kustomize base and push as OCI artifact | `source?`, `ociSource?`, `parameters?`, `parametersFile?`, `entrypoint?`, `address`, `tag`, `user?`, `password?` | OCI reference string |
+| `RenderInstallYAML()`     | Render KCL → kustomize base → flat `install.yaml` for `kubectl apply -f` | `source?`, `ociSource?`, `parameters?`, `parametersFile?`, `entrypoint?`, `subpath?`, `kustomizeVersion?` | Single multi-doc YAML file |
 
 ### Clusterbook Functions
 

--- a/kcl/kustomize.go
+++ b/kcl/kustomize.go
@@ -110,6 +110,69 @@ done
 	return ctr.Directory("/output"), nil
 }
 
+// RenderInstallYAML renders the KCL → kustomize base and then runs
+// `kustomize build` against it to produce a single flat multi-doc YAML
+// suitable for `kubectl apply -f install.yaml` deployments.
+//
+// The use case is operator-style releases where users want a one-line
+// install path (`kubectl apply -f https://.../install.yaml`) without
+// having to learn kustomize or pull an OCI artifact. Pair it with a
+// `gh release upload` step in CI to attach it to the GitHub release.
+//
+// Example usage:
+//
+//	dagger call render-install-yaml \
+//	  --source ./kcl \
+//	  --parameters-file /tmp/release/profile.yaml \
+//	  export --path=/tmp/install.yaml
+func (m *Kcl) RenderInstallYAML(
+	ctx context.Context,
+	// Local source directory (optional if using OCI source)
+	// +optional
+	source *dagger.Directory,
+	// OCI source path (e.g., oci://ghcr.io/stuttgart-things/kcl-flux-instance)
+	// +optional
+	ociSource string,
+	// KCL parameters as comma-separated key=value pairs
+	// +optional
+	parameters string,
+	// YAML/JSON file containing KCL parameters as key-value pairs
+	// +optional
+	parametersFile *dagger.File,
+	// Entry point file name
+	// +optional
+	// +default="main.k"
+	entrypoint string,
+	// Sub-path inside source to cd into before running kcl.
+	// +optional
+	subpath string,
+	// Kustomize binary version pinned into the render container.
+	// +optional
+	// +default="v5.4.3"
+	kustomizeVersion string,
+) (*dagger.File, error) {
+
+	baseDir, err := m.RenderKustomizeBase(ctx, source, ociSource, parameters, parametersFile, entrypoint, subpath)
+	if err != nil {
+		return nil, err
+	}
+
+	// Install kustomize, then run `kustomize build` against the rendered
+	// base. The result is one multi-doc YAML written to /out/install.yaml.
+	// Pinning the version keeps releases reproducible.
+	installCmd := fmt.Sprintf(
+		"curl -sL https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/%s/kustomize_%s_linux_amd64.tar.gz | tar xz -C /usr/local/bin kustomize",
+		kustomizeVersion, kustomizeVersion,
+	)
+
+	ctr := m.container().
+		WithExec([]string{"sh", "-c", installCmd}).
+		WithMountedDirectory("/base", baseDir).
+		WithExec([]string{"sh", "-c", "mkdir -p /out && kustomize build /base > /out/install.yaml"})
+
+	return ctr.File("/out/install.yaml"), nil
+}
+
 // PushKustomizeBase renders a kustomize base from KCL and pushes it as an OCI artifact.
 // It calls RenderKustomizeBase() internally, then uses oras to push the result.
 //


### PR DESCRIPTION
## Summary
- Adds `RenderInstallYAML` to the `kcl` module: runs `RenderKustomizeBase` then `kustomize build` to emit a single flat multi-doc `install.yaml` suitable for `kubectl apply -f install.yaml` operator-style releases.
- Pinnable kustomize version via `--kustomize-version` (default `v5.4.3`) for reproducible releases.
- Documents the new function in `kcl/README.md` (new section + Functions table row).
- Adds a `test-kcl-install-yaml` Taskfile target and extends `test-kcl` with a render + `grep '^kind:'` sanity check against the existing `tests/kcl/test-kustomize-project` fixture.

## Test plan
- [ ] `task test-kcl-install-yaml` passes locally
- [ ] `task test-kcl` passes locally (covers the new step alongside the existing kustomize-base test)
- [ ] Inspect `/tmp/dagger/kcl-test-install.yaml` — single multi-doc YAML, contains Deployment + Service from the fixture
- [ ] Spot-check `--kustomize-version` override with a non-default tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)