### PR TITLE
feat: pin every module's go.mod to go 1.26.0

### DIFF
--- a/ansible/go.mod
+++ b/ansible/go.mod
@@ -1,6 +1,6 @@
 module dagger/ansible
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/argocd/go.mod
+++ b/argocd/go.mod
@@ -1,6 +1,6 @@
 module dagger/argocd
 
-go 1.26.2
+go 1.26.0
 
 require (
 	dagger.io/dagger v0.20.8

--- a/crane/go.mod
+++ b/crane/go.mod
@@ -1,6 +1,6 @@
 module dagger/crane
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/crossplane/go.mod
+++ b/crossplane/go.mod
@@ -1,6 +1,6 @@
 module dagger/crossplane
 
-go 1.25.5
+go 1.26.0
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/dependencies/go.mod
+++ b/dependencies/go.mod
@@ -1,6 +1,6 @@
 module dagger/dependencies
 
-go 1.25.3
+go 1.26.0
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/docker/go.mod
+++ b/docker/go.mod
@@ -1,6 +1,6 @@
 module dagger/docker
 
-go 1.25.0
+go 1.26.0
 
 require (
 	emperror.dev/errors v0.8.1

--- a/flux/go.mod
+++ b/flux/go.mod
@@ -1,6 +1,6 @@
 module dagger/flux
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/git/go.mod
+++ b/git/go.mod
@@ -1,6 +1,6 @@
 module dagger/git
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/99designs/gqlgen v0.17.90

--- a/gitlab/go.mod
+++ b/gitlab/go.mod
@@ -1,6 +1,6 @@
 module dagger/gitlab
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,6 +1,6 @@
 module dagger/go
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/helm/go.mod
+++ b/helm/go.mod
@@ -1,6 +1,6 @@
 module dagger/helm
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/99designs/gqlgen v0.17.90

--- a/homerun/go.mod
+++ b/homerun/go.mod
@@ -1,6 +1,6 @@
 module dagger/homerun
 
-go 1.25.3
+go 1.26.0
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/hugo/go.mod
+++ b/hugo/go.mod
@@ -1,6 +1,6 @@
 module dagger/hugo
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/kcl/go.mod
+++ b/kcl/go.mod
@@ -1,6 +1,6 @@
 module dagger/kcl
 
-go 1.25.1
+go 1.26.0
 
 require (
 	github.com/99designs/gqlgen v0.17.90

--- a/kubernetes/go.mod
+++ b/kubernetes/go.mod
@@ -1,6 +1,6 @@
 module dagger/kubernetes
 
-go 1.25.3
+go 1.26.0
 
 require (
 	github.com/99designs/gqlgen v0.17.90

--- a/kyverno/go.mod
+++ b/kyverno/go.mod
@@ -1,6 +1,6 @@
 module dagger/kyverno
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/linting/go.mod
+++ b/linting/go.mod
@@ -1,6 +1,6 @@
 module dagger/linting
 
-go 1.25.1
+go 1.26.0
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/oci/go.mod
+++ b/oci/go.mod
@@ -1,6 +1,6 @@
 module dagger/oci
 
-go 1.26.1
+go 1.26.0
 
 require (
 	dagger.io/dagger v0.20.8

--- a/packer/go.mod
+++ b/packer/go.mod
@@ -1,6 +1,6 @@
 module dagger/packer
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/release/go.mod
+++ b/release/go.mod
@@ -1,6 +1,6 @@
 module dagger/release
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/slidev/go.mod
+++ b/slidev/go.mod
@@ -1,6 +1,6 @@
 module dagger/slidev
 
-go 1.26.2
+go 1.26.0
 
 require (
 	dagger.io/dagger v0.20.8

--- a/sops/go.mod
+++ b/sops/go.mod
@@ -1,6 +1,6 @@
 module dagger/sops
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/templating/go.mod
+++ b/templating/go.mod
@@ -1,6 +1,6 @@
 module dagger/templating
 
-go 1.25.3
+go 1.26.0
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/terraform/go.mod
+++ b/terraform/go.mod
@@ -1,6 +1,6 @@
 module dagger/terraform
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/trivy/go.mod
+++ b/trivy/go.mod
@@ -1,6 +1,6 @@
 module dagger/trivy
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/99designs/gqlgen v0.17.90


### PR DESCRIPTION
## Summary
- Sets the `go` directive in every module's `go.mod` to **1.26.0** (range was 1.25.0 → 1.26.2 across 27 modules).
- `clusterbook` and `python` were already on 1.26.0 — 25 files actually changed.
- No `go.sum` churn — pure directive bump, `go mod tidy` was a no-op for everything.

Closes P1.2 in #262.

## Test plan
- [x] `go mod tidy` succeeds on all 27 modules with `go 1.26.0`.
- [ ] CI build (semantic-release lint job) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)