### PR TITLE
fix(git): cache-bust gh repo clone to avoid stale origin HEAD

### DIFF
--- a/git/github.go
+++ b/git/github.go
@@ -5,6 +5,7 @@ import (
 	"dagger/git/internal/dagger"
 	"fmt"
 	"strings"
+	"time"
 )
 
 var (
@@ -264,8 +265,11 @@ func (m *Git) CloneGithub(
 		fmt.Errorf("CONTAINER INIT FAILED: %w", err)
 	}
 
-	// Use gh to clone with authentication and checkout the specific branch
+	// Use gh to clone with authentication and checkout the specific branch.
+	// CACHE_BUSTER forces a fresh clone on every run so callers (AddFile/AddFiles)
+	// don't push on top of a stale origin HEAD (blueprints#158).
 	ctr = ctr.
+		WithEnvVariable("CACHE_BUSTER", fmt.Sprintf("%d", time.Now().UnixNano())).
 		WithSecretVariable("GH_TOKEN", token).
 		WithEnvVariable("GH_REPO", repository).
 		WithExec([]string{"gh", "repo", "clone", repository, workDir, "--", "--branch", ref})
@@ -386,7 +390,11 @@ func (m *Git) AddFolderToGithubBranch(
 
 	// Clone via gh CLI inside our own container (avoids the upstream gh module,
 	// whose apko-built base image fails on shared cache volumes with "permission denied").
+	// CACHE_BUSTER forces Dagger to re-run clone+fetch+checkout every invocation;
+	// without it the cache key is static and /src ends up at a stale origin/main,
+	// causing "fetch first" push rejections (blueprints#158).
 	ctr = ctr.
+		WithEnvVariable("CACHE_BUSTER", fmt.Sprintf("%d", time.Now().UnixNano())).
 		WithSecretVariable("GH_TOKEN", token).
 		WithEnvVariable("GH_REPO", repository).
 		WithExec([]string{"gh", "repo", "clone", repository, workDir})


### PR DESCRIPTION
## Summary

- Inject `CACHE_BUSTER=time.Now().UnixNano()` before `gh repo clone` in `CloneGithub` and `AddFolderToGithubBranch`.
- Defeats Dagger's content-hash cache for the clone op, which transitively re-runs the dependent `git fetch origin --force` and `git checkout` execs.
- Fixes the "fetch first" push rejection seen when the cached `/src` is at a stale `origin/main` after a fresh upstream commit.

## Why

Per stuttgart-things/blueprints#158 — `gh repo clone /src`, `git fetch origin --force`, and `git checkout main` were all marked CACHED across runs. Static cache key (repo URL + secret-by-ID) meant the in-container working tree retained its old HEAD, so commits landed on a stale base and `git push` was rejected.

Witnesses:
- `argocd/bootstrap-clusterbook-cluster` first run on `argocd-cluster-kinde-dev2` (stuttgart-things/stuttgart-things#2142).
- `vm/executeAnsibleEncryptAndCommit` on the `shuffle` runner — Dagger Cloud trace `4da1672339ad82b8c9d25a878949e4a2`.

Both required `dagger core engine local-cache prune` on the runner host as a manual workaround.

## Test plan

- [ ] Two consecutive runs of `argocd/bootstrap-clusterbook-cluster` on the same runner host, with a fresh commit pushed to `origin/main` between runs, both succeed without manual cache prune.
- [ ] Same for `vm/executeAnsibleEncryptAndCommit`.
- [ ] Dagger Cloud trace shows `gh repo clone` and `git fetch` no longer marked CACHED on subsequent runs.
- [ ] No regression in cache hit rate for content-addressable steps (KCL render, sops encrypt) — they don't sit downstream of the busted env var.

Refs stuttgart-things/blueprints#158.

🤖 Generated with [Claude Code](https://claude.com/claude-code)