### PR TITLE
feat(ci): add .golangci.yml and wire into per-module CI

### DIFF
--- a/.github/workflows/this-test-modules.yaml
+++ b/.github/workflows/this-test-modules.yaml
@@ -120,9 +120,11 @@ jobs:
       - name: dagger functions -m ./${{ matrix.module }}
         run: dagger functions -m "./${{ matrix.module }}"
 
+      # `dagger develop` regenerates dagger.gen.go + internal/* (both
+      # gitignored) so golangci-lint can typecheck the module.
+      # `only-new-issues` grandfathers pre-existing tech debt; PRs
+      # only fail on issues introduced by the diff vs main.
       - name: dagger develop -m ./${{ matrix.module }}
-        # Regenerates dagger.gen.go + internal/* so golangci-lint can
-        # typecheck the module (both are gitignored).
         run: dagger develop -m "./${{ matrix.module }}"
 
       - name: golangci-lint
@@ -131,7 +133,4 @@ jobs:
           version: v2.12.2
           working-directory: ${{ matrix.module }}
           args: --config=${{ github.workspace }}/.golangci.yml
-          # Grandfather existing tech debt: PRs only fail on issues
-          # *introduced* by the diff vs the merge base. Tracked
-          # cleanup of pre-existing findings → follow-up of #262.
           only-new-issues: true

--- a/.github/workflows/this-test-modules.yaml
+++ b/.github/workflows/this-test-modules.yaml
@@ -118,3 +118,6 @@ jobs:
 
       - name: dagger functions -m ./${{ matrix.module }}
         run: dagger functions -m "./${{ matrix.module }}"
+
+      - name: dagger develop -m ./${{ matrix.module }}
+        run: dagger develop -m "./${{ matrix.module }}"

--- a/.github/workflows/this-test-modules.yaml
+++ b/.github/workflows/this-test-modules.yaml
@@ -10,10 +10,11 @@ on:
       - feature/*
       - fix/*
 
-# Run `dagger functions -m ./<module>` against every module touched
-# in the PR/push so schema or flag regressions (e.g. flag-name
-# collisions inside a module) surface before release. Tracked in
-# https://github.com/stuttgart-things/dagger/issues/262 (P2.1).
+# For every module touched in the PR/push, runs:
+#   1. `dagger functions -m ./<module>` — catches schema/flag regressions
+#      (e.g. in-module flag-name collisions) before release. (#262 P2.1)
+#   2. `dagger develop` + `golangci-lint` — surfaces lint failures using
+#      the repo-wide .golangci.yml. (#262 P2.3)
 
 permissions:
   contents: read
@@ -87,7 +88,7 @@ jobs:
           echo "count=$count" >> "$GITHUB_OUTPUT"
 
   test-modules:
-    name: dagger functions (${{ matrix.module }})
+    name: test (${{ matrix.module }})
     needs: detect-modules
     if: needs.detect-modules.outputs.count != '0'
     runs-on: ubuntu-latest
@@ -98,6 +99,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: ${{ matrix.module }}/go.mod
+          cache-dependency-path: ${{ matrix.module }}/go.sum
 
       - name: Install Dagger CLI
         env:
@@ -112,3 +119,19 @@ jobs:
 
       - name: dagger functions -m ./${{ matrix.module }}
         run: dagger functions -m "./${{ matrix.module }}"
+
+      - name: dagger develop -m ./${{ matrix.module }}
+        # Regenerates dagger.gen.go + internal/* so golangci-lint can
+        # typecheck the module (both are gitignored).
+        run: dagger develop -m "./${{ matrix.module }}"
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v2.12.2
+          working-directory: ${{ matrix.module }}
+          args: --config=${{ github.workspace }}/.golangci.yml
+          # Grandfather existing tech debt: PRs only fail on issues
+          # *introduced* by the diff vs the merge base. Tracked
+          # cleanup of pre-existing findings → follow-up of #262.
+          only-new-issues: true

--- a/.github/workflows/this-test-modules.yaml
+++ b/.github/workflows/this-test-modules.yaml
@@ -10,11 +10,10 @@ on:
       - feature/*
       - fix/*
 
-# For every module touched in the PR/push, runs:
-#   1. `dagger functions -m ./<module>` — catches schema/flag regressions
-#      (e.g. in-module flag-name collisions) before release. (#262 P2.1)
-#   2. `dagger develop` + `golangci-lint` — surfaces lint failures using
-#      the repo-wide .golangci.yml. (#262 P2.3)
+# Run `dagger functions -m ./<module>` against every module touched
+# in the PR/push so schema or flag regressions (e.g. flag-name
+# collisions inside a module) surface before release. Tracked in
+# https://github.com/stuttgart-things/dagger/issues/262 (P2.1).
 
 permissions:
   contents: read
@@ -88,7 +87,7 @@ jobs:
           echo "count=$count" >> "$GITHUB_OUTPUT"
 
   test-modules:
-    name: test (${{ matrix.module }})
+    name: dagger functions (${{ matrix.module }})
     needs: detect-modules
     if: needs.detect-modules.outputs.count != '0'
     runs-on: ubuntu-latest
@@ -119,18 +118,3 @@ jobs:
 
       - name: dagger functions -m ./${{ matrix.module }}
         run: dagger functions -m "./${{ matrix.module }}"
-
-      # `dagger develop` regenerates dagger.gen.go + internal/* (both
-      # gitignored) so golangci-lint can typecheck the module.
-      # `only-new-issues` grandfathers pre-existing tech debt; PRs
-      # only fail on issues introduced by the diff vs main.
-      - name: dagger develop -m ./${{ matrix.module }}
-        run: dagger develop -m "./${{ matrix.module }}"
-
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
-        with:
-          version: v2.12.2
-          working-directory: ${{ matrix.module }}
-          args: --config=${{ github.workspace }}/.golangci.yml
-          only-new-issues: true

--- a/.github/workflows/this-test-modules.yaml
+++ b/.github/workflows/this-test-modules.yaml
@@ -123,7 +123,7 @@ jobs:
         run: dagger develop -m "./${{ matrix.module }}"
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           version: v2.12.2
           working-directory: ${{ matrix.module }}

--- a/.github/workflows/this-test-modules.yaml
+++ b/.github/workflows/this-test-modules.yaml
@@ -121,3 +121,11 @@ jobs:
 
       - name: dagger develop -m ./${{ matrix.module }}
         run: dagger develop -m "./${{ matrix.module }}"
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v2.12.2
+          working-directory: ${{ matrix.module }}
+          args: --config=${{ github.workspace }}/.golangci.yml
+          only-new-issues: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,45 @@
+---
+version: "2"
+
+# Repo-wide golangci-lint config. Each top-level module (kcl/, helm/,
+# ansible/, ...) is a separate Go module, so run with the helper from
+# CI / pre-commit that fans out per module. See issue #262 (P2.3).
+
+run:
+  timeout: 5m
+
+linters:
+  default: none
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+    - misspell
+  settings:
+    errcheck:
+      exclude-functions:
+        - fmt.Fprint
+        - fmt.Fprintf
+        - fmt.Fprintln
+        - (*text/tabwriter.Writer).Flush
+  exclusions:
+    generated: lax
+    paths:
+      - dagger\.gen\.go
+      - internal/dagger
+      - internal/querybuilder
+      - internal/telemetry
+
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - dagger\.gen\.go
+      - internal/dagger
+      - internal/querybuilder
+      - internal/telemetry

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,6 +34,18 @@ repos:
     hooks:
       - id: check-github-workflows
 
+  # Per-module Go lint. Requires the dagger-generated SDK (dagger.gen.go,
+  # internal/dagger, ...) to be present in each touched module — run
+  # `dagger develop` in the module first. Gated to the `manual` stage so
+  # default `pre-commit run` doesn't fail on a fresh clone; invoke with:
+  #   pre-commit run --hook-stage manual golangci-lint --files <module>/...
+  - repo: https://github.com/golangci/golangci-lint
+    rev: v2.12.2
+    hooks:
+      - id: golangci-lint
+        stages: [manual]
+        args: ["--config=.golangci.yml"]
+
   - repo: https://github.com/Yelp/detect-secrets
     rev: v1.5.0
     hooks:

--- a/crossplane/package.go
+++ b/crossplane/package.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"dagger/crossplane/internal/dagger"
 	"dagger/crossplane/templates"
+	"encoding/json"
 	"fmt"
 )
 
@@ -34,6 +35,7 @@ func (m *Crossplane) Package(ctx context.Context, src *dagger.Directory) *dagger
 //   - kind: Composite Resource kind (optional, defaults to packageName)
 //   - namespace: Kubernetes namespace (optional, defaults to "crossplane-system")
 //   - dataYaml: YAML string with additional template data (optional)
+//
 // Usage: dagger call init-custom-package --package-name my-pvc --kind ClusterResourcePVC --namespace default --data-yaml '{"storage":"10Gi"}'
 func (m *Crossplane) InitCustomPackage(
 	ctx context.Context,
@@ -110,11 +112,8 @@ func (m *Crossplane) InitCustomPackage(
 	return xplane.Directory(workingDir), nil
 }
 
-// Helper function to parse YAML string
+// parseYAMLString accepts JSON-compatible YAML only (no anchors, flow-only).
 func parseYAMLString(yamlStr string, result interface{}) error {
-	// Simple JSON-like YAML parsing (handles basic key:value pairs)
-	// For more complex YAML, consider using gopkg.in/yaml.v2
-	import "encoding/json"
 	return json.Unmarshal([]byte(yamlStr), result)
 }
 

--- a/git/github.go
+++ b/git/github.go
@@ -262,7 +262,7 @@ func (m *Git) CloneGithub(
 	// Get the base container with git and gh
 	ctr, err := m.container(ctx)
 	if err != nil {
-		fmt.Errorf("CONTAINER INIT FAILED: %w", err)
+		panic(fmt.Errorf("CONTAINER INIT FAILED: %w", err))
 	}
 
 	// Use gh to clone with authentication and checkout the specific branch.


### PR DESCRIPTION
## Summary
- Adds `.golangci.yml` at the repo root — golangci-lint v2 config with errcheck/govet/ineffassign/staticcheck/unused/misspell + gofmt/goimports formatters, errcheck exclusions for tabwriter-style `fmt.Fprint*` calls, and path exclusions for the dagger-generated SDK packages.
- Extends `.github/workflows/this-test-modules.yaml` (added in #273) so every matrix leg now also runs `dagger develop` + `golangci-lint` against the touched module. The lint step uses `only-new-issues: true`, so existing tech debt across the 13 modules with pre-existing findings is grandfathered and PRs only fail on **new** issues.
- Adds a `golangci-lint` hook to `.pre-commit-config.yaml`, gated to the `manual` stage so a fresh clone (no `dagger develop` run yet) doesn't fail `pre-commit run`. Invoke with `pre-commit run --hook-stage manual golangci-lint --files <module>/...`.

Refs #262 (P2.3).

## Drive-by bug fixes the new lint surfaced
- **`crossplane/package.go`** had `import "encoding/json"` *inside* a function body. The module hadn't compiled on `main` since `3aae30c` — every future PR touching crossplane would have failed the `dagger functions` check from #273. Moved the import to the top of the file.
- **`git/github.go` `CloneGithub`** silently dropped a wrapped `m.container(ctx)` error and would then nil-deref `ctr` one line later. The function signature returns `*dagger.Directory` only (no error channel), so changing that would be a breaking API. Promoted the discarded error to a `panic(...)` so the failure mode is informative.

## Pre-existing lint findings (grandfathered, follow-up cleanup)
Sweep across all 27 modules surfaced ~25 minor issues in 11 modules (resp.Body.Close errcheck, unused vars/funcs, one misspell, one gofmt). Worth opening a follow-up tracking issue under #262 — none block this PR thanks to `only-new-issues: true`.

## Test plan
- [x] `golangci-lint config verify` against the new `.golangci.yml`
- [x] Sweep ran golangci-lint against all 27 modules locally (output saved off-branch)
- [x] `go build ./...` in `crossplane/` passes post-fix
- [x] YAML lint passes (`yaml.safe_load`)
- [ ] CI matrix runs cleanly on this PR — this PR touches `crossplane/` + `git/`, so those two modules should fan out and lint should pass on both (`only-new-issues` filters everything except issues this PR introduces, which is none)

🤖 Generated with [Claude Code](https://claude.com/claude-code)