### PR TITLE
docs(homerun): replace stale `dagger init` boilerplate with real description

### DIFF
--- a/homerun/main.go
+++ b/homerun/main.go
@@ -1,16 +1,9 @@
-// A generated module for Homerun functions
+// Homerun provides Redis-backed test scaffolding for other Dagger modules.
 //
-// This module has been generated via dagger init and serves as a reference to
-// basic module structure as you get started with Dagger.
-//
-// Two functions have been pre-created. You can modify, delete, or add to them,
-// as needed. They demonstrate usage of arguments and return types using simple
-// echo and grep commands. The functions can be called from the dagger CLI or
-// from one of the SDKs.
-//
-// The first line in this comment block is a short description line and the
-// rest is a long description with more detail on the module's purpose or usage,
-// if appropriate. All modules should have a short description.
+// It exposes a Redis service (optionally password-protected), a randomly
+// generated password helper, an interactive redis-cli container, a one-shot
+// connectivity probe, and a `RunTestWithRedis` runner that wires a Redis
+// service into a Go test container — all without requiring an external Redis.
 
 package main
 


### PR DESCRIPTION
## Summary
- `homerun/main.go` still carried the `dagger init` placeholder ("serves as a reference to basic module structure as you get started with Dagger") even though the module has been built out with six real Redis functions.
- Replaces the docstring with a short description of what the module actually exposes.

## Why
The stale docstring was the only thing making issue #262 still classify `homerun` as a "stub to retire or implement." With this in place, the audit reality matches the code reality:

- `RedisService`, `RunRedis`, `RedisCli`, `TestRedisConnection`, `GeneratePassword`, `RunTestWithRedis` — all real, used.
- Wired into the Taskfile (`task test-homerun`) and listed in the top-level `README.md` module index.

So this closes the homerun bullet under P3 of #262 — no module retirement needed.

Refs #262.

## Test plan
- [x] `go build ./...` in `homerun/` passes
- [x] No functional change — purely a top-of-file comment edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)