### PR TITLE
refactor(dependencies): extract ansible bash scripts via go:embed

### DIFF
--- a/dependencies/ansible.go
+++ b/dependencies/ansible.go
@@ -3,9 +3,16 @@ package main
 import (
 	"context"
 	"dagger/dependencies/internal/dagger"
+	_ "embed"
 	"fmt"
 	"strings"
 )
+
+//go:embed scripts/check-ansible-updates.sh
+var checkAnsibleUpdatesScript string
+
+//go:embed scripts/update-ansible-requirements.sh
+var updateAnsibleRequirementsScript string
 
 // GalaxyCollection represents an Ansible Galaxy collection metadata
 type GalaxyCollection struct {
@@ -46,112 +53,9 @@ func (m *Dependencies) UpdateAnsibleRequirements(
 		container = container.WithSecretVariable("GITHUB_TOKEN", githubToken)
 	}
 
-	// Create a script to check for updates
-	script := `#!/bin/bash
-set -e
-
-echo "=== Checking Ansible Collection Updates ==="
-echo ""
-
-# Read the requirements file
-REQUIREMENTS_FILE="/work/requirements.yaml"
-
-# Function to get latest version from Ansible Galaxy
-get_galaxy_version() {
-  local collection=$1
-  local namespace=$(echo $collection | cut -d'.' -f1)
-  local name=$(echo $collection | cut -d'.' -f2)
-
-  version=$(curl -s "https://galaxy.ansible.com/api/v3/plugin/ansible/content/published/collections/index/${namespace}/${name}/" \
-    | jq -r '.highest_version.version // "unknown"' 2>/dev/null || echo "unknown")
-
-  echo "$version"
-}
-
-# Function to get latest GitHub release version
-get_github_release_version() {
-  local collection_prefix=$1
-  local auth_header=""
-
-  if [ -n "$GITHUB_TOKEN" ]; then
-    auth_header="-H \"Authorization: Bearer $GITHUB_TOKEN\""
-  fi
-
-  version=$(curl -s $auth_header "https://api.github.com/repos/stuttgart-things/ansible/releases" \
-    | jq -r "[.[] | select(.tag_name | contains(\"${collection_prefix}\")) | .tag_name] | first" 2>/dev/null || echo "unknown")
-
-  echo "$version"
-}
-
-# Check Galaxy collections
-echo "### Ansible Galaxy Collections ###"
-echo ""
-
-yq e '.collections[] | select(.name | test("^[a-z]+\\.[a-z_]+$")) | .name' "$REQUIREMENTS_FILE" | while read -r collection; do
-  if [ -n "$collection" ]; then
-    current_version=$(yq e ".collections[] | select(.name == \"$collection\") | .version" "$REQUIREMENTS_FILE")
-    latest_version=$(get_galaxy_version "$collection")
-
-    if [ "$latest_version" != "unknown" ]; then
-      if [ "$current_version" != "$latest_version" ]; then
-        echo "🔼 $collection"
-        echo "   Current: $current_version"
-        echo "   Latest:  $latest_version"
-        echo "   Update:  yq e -i '(.collections[] | select(.name == \"$collection\") | .version) = \"$latest_version\"' requirements.yaml"
-        echo ""
-      else
-        echo "✅ $collection: $current_version (up-to-date)"
-        echo ""
-      fi
-    else
-      echo "⚠️  $collection: $current_version (could not check)"
-      echo ""
-    fi
-  fi
-done
-
-# Check GitHub release collections
-echo ""
-echo "### Stuttgart-Things Custom Collections (GitHub Releases) ###"
-echo ""
-
-for collection_prefix in sthings-container sthings-baseos sthings-awx sthings-rke; do
-  current_url=$(yq e ".collections[] | select(.name | contains(\"$collection_prefix\")) | .name" "$REQUIREMENTS_FILE")
-
-  if [ -n "$current_url" ]; then
-    # Extract version from URL pattern like: sthings-container-25.1.168.tar.gz
-    current_version=$(echo "$current_url" | grep -oP "${collection_prefix}-\K[0-9.]+" || echo "unknown")
-
-    latest_tag=$(get_github_release_version "$collection_prefix")
-
-    if [ "$latest_tag" != "unknown" ] && [ "$latest_tag" != "null" ]; then
-      latest_version=$(echo "$latest_tag" | grep -oP "${collection_prefix}-\K[0-9.]+" || echo "unknown")
-
-      if [ "$latest_version" != "unknown" ] && [ "$current_version" != "$latest_version" ]; then
-        new_url="https://github.com/stuttgart-things/ansible/releases/download/${latest_tag}/${latest_tag}.tar.gz"
-        echo "🔼 $collection_prefix"
-        echo "   Current: $current_version"
-        echo "   Latest:  $latest_version"
-        echo "   Update:  yq e -i '(.collections[] | select(.name | contains(\"$collection_prefix\")) | .name) = \"$new_url\"' requirements.yaml"
-        echo ""
-      else
-        echo "✅ $collection_prefix: $current_version (up-to-date)"
-        echo ""
-      fi
-    else
-      echo "⚠️  $collection_prefix: $current_version (could not check GitHub releases)"
-      echo ""
-    fi
-  fi
-done
-
-echo ""
-echo "=== Check Complete ==="
-`
-
 	// Execute the script
 	result, err := container.
-		WithNewFile("/tmp/check-updates.sh", script, dagger.ContainerWithNewFileOpts{
+		WithNewFile("/tmp/check-updates.sh", checkAnsibleUpdatesScript, dagger.ContainerWithNewFileOpts{
 			Permissions: 0755,
 		}).
 		WithExec([]string{"/bin/bash", "/tmp/check-updates.sh"}).
@@ -205,89 +109,7 @@ func (m *Dependencies) UpdateAnsibleRequirementsAndApply(
 		collections = strings.Split(collectionsToUpdate, ",")
 	}
 
-	// Create update script
-	updateScript := fmt.Sprintf(`#!/bin/bash
-set -e
-
-REQUIREMENTS_FILE="/work/requirements.yaml"
-UPDATE_ALL=%v
-COLLECTIONS_TO_UPDATE=(%s)
-
-# Function to check if collection should be updated
-should_update() {
-  local collection=$1
-
-  if [ "$UPDATE_ALL" = "true" ]; then
-    return 0
-  fi
-
-  for col in "${COLLECTIONS_TO_UPDATE[@]}"; do
-    if [ "$col" = "$collection" ]; then
-      return 0
-    fi
-  done
-
-  return 1
-}
-
-# Function to get latest version from Ansible Galaxy
-get_galaxy_version() {
-  local collection=$1
-  local namespace=$(echo $collection | cut -d'.' -f1)
-  local name=$(echo $collection | cut -d'.' -f2)
-
-  version=$(curl -s "https://galaxy.ansible.com/api/v3/plugin/ansible/content/published/collections/index/${namespace}/${name}/" \
-    | jq -r '.highest_version.version // "unknown"' 2>/dev/null || echo "unknown")
-
-  echo "$version"
-}
-
-# Function to get latest GitHub release version
-get_github_release_version() {
-  local collection_prefix=$1
-  local auth_header=""
-
-  if [ -n "$GITHUB_TOKEN" ]; then
-    auth_header="-H \"Authorization: Bearer $GITHUB_TOKEN\""
-  fi
-
-  version=$(curl -s $auth_header "https://api.github.com/repos/stuttgart-things/ansible/releases" \
-    | jq -r "[.[] | select(.tag_name | contains(\"${collection_prefix}\")) | .tag_name] | first" 2>/dev/null || echo "unknown")
-
-  echo "$version"
-}
-
-echo "Updating Ansible collections..."
-echo ""
-
-# Update Galaxy collections
-yq e '.collections[] | select(.name | test("^[a-z]+\\.[a-z_]+$")) | .name' "$REQUIREMENTS_FILE" | while read -r collection; do
-  if [ -n "$collection" ] && should_update "$collection"; then
-    latest_version=$(get_galaxy_version "$collection")
-
-    if [ "$latest_version" != "unknown" ]; then
-      yq e -i "(.collections[] | select(.name == \"$collection\") | .version) = \"$latest_version\"" "$REQUIREMENTS_FILE"
-      echo "Updated $collection to $latest_version"
-    fi
-  fi
-done
-
-# Update GitHub release collections
-for collection_prefix in sthings-container sthings-baseos sthings-awx sthings-rke; do
-  if should_update "$collection_prefix"; then
-    latest_tag=$(get_github_release_version "$collection_prefix")
-
-    if [ "$latest_tag" != "unknown" ] && [ "$latest_tag" != "null" ]; then
-      new_url="https://github.com/stuttgart-things/ansible/releases/download/${latest_tag}/${latest_tag}.tar.gz"
-      yq e -i "(.collections[] | select(.name | contains(\"$collection_prefix\")) | .name) = \"$new_url\"" "$REQUIREMENTS_FILE"
-      echo "Updated $collection_prefix to $latest_tag"
-    fi
-  fi
-done
-
-echo ""
-echo "Update complete!"
-`, updateAll, strings.Join(collections, " "))
+	updateScript := fmt.Sprintf(updateAnsibleRequirementsScript, updateAll, strings.Join(collections, " "))
 
 	// Execute the update script
 	container = container.

--- a/dependencies/scripts/check-ansible-updates.sh
+++ b/dependencies/scripts/check-ansible-updates.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+set -e
+
+echo "=== Checking Ansible Collection Updates ==="
+echo ""
+
+# Read the requirements file
+REQUIREMENTS_FILE="/work/requirements.yaml"
+
+# Function to get latest version from Ansible Galaxy
+get_galaxy_version() {
+  local collection=$1
+  local namespace=$(echo $collection | cut -d'.' -f1)
+  local name=$(echo $collection | cut -d'.' -f2)
+
+  version=$(curl -s "https://galaxy.ansible.com/api/v3/plugin/ansible/content/published/collections/index/${namespace}/${name}/" \
+    | jq -r '.highest_version.version // "unknown"' 2>/dev/null || echo "unknown")
+
+  echo "$version"
+}
+
+# Function to get latest GitHub release version
+get_github_release_version() {
+  local collection_prefix=$1
+  local auth_header=""
+
+  if [ -n "$GITHUB_TOKEN" ]; then
+    auth_header="-H \"Authorization: Bearer $GITHUB_TOKEN\""
+  fi
+
+  version=$(curl -s $auth_header "https://api.github.com/repos/stuttgart-things/ansible/releases" \
+    | jq -r "[.[] | select(.tag_name | contains(\"${collection_prefix}\")) | .tag_name] | first" 2>/dev/null || echo "unknown")
+
+  echo "$version"
+}
+
+# Check Galaxy collections
+echo "### Ansible Galaxy Collections ###"
+echo ""
+
+yq e '.collections[] | select(.name | test("^[a-z]+\\.[a-z_]+$")) | .name' "$REQUIREMENTS_FILE" | while read -r collection; do
+  if [ -n "$collection" ]; then
+    current_version=$(yq e ".collections[] | select(.name == \"$collection\") | .version" "$REQUIREMENTS_FILE")
+    latest_version=$(get_galaxy_version "$collection")
+
+    if [ "$latest_version" != "unknown" ]; then
+      if [ "$current_version" != "$latest_version" ]; then
+        echo "🔼 $collection"
+        echo "   Current: $current_version"
+        echo "   Latest:  $latest_version"
+        echo "   Update:  yq e -i '(.collections[] | select(.name == \"$collection\") | .version) = \"$latest_version\"' requirements.yaml"
+        echo ""
+      else
+        echo "✅ $collection: $current_version (up-to-date)"
+        echo ""
+      fi
+    else
+      echo "⚠️  $collection: $current_version (could not check)"
+      echo ""
+    fi
+  fi
+done
+
+# Check GitHub release collections
+echo ""
+echo "### Stuttgart-Things Custom Collections (GitHub Releases) ###"
+echo ""
+
+for collection_prefix in sthings-container sthings-baseos sthings-awx sthings-rke; do
+  current_url=$(yq e ".collections[] | select(.name | contains(\"$collection_prefix\")) | .name" "$REQUIREMENTS_FILE")
+
+  if [ -n "$current_url" ]; then
+    # Extract version from URL pattern like: sthings-container-25.1.168.tar.gz
+    current_version=$(echo "$current_url" | grep -oP "${collection_prefix}-\K[0-9.]+" || echo "unknown")
+
+    latest_tag=$(get_github_release_version "$collection_prefix")
+
+    if [ "$latest_tag" != "unknown" ] && [ "$latest_tag" != "null" ]; then
+      latest_version=$(echo "$latest_tag" | grep -oP "${collection_prefix}-\K[0-9.]+" || echo "unknown")
+
+      if [ "$latest_version" != "unknown" ] && [ "$current_version" != "$latest_version" ]; then
+        new_url="https://github.com/stuttgart-things/ansible/releases/download/${latest_tag}/${latest_tag}.tar.gz"
+        echo "🔼 $collection_prefix"
+        echo "   Current: $current_version"
+        echo "   Latest:  $latest_version"
+        echo "   Update:  yq e -i '(.collections[] | select(.name | contains(\"$collection_prefix\")) | .name) = \"$new_url\"' requirements.yaml"
+        echo ""
+      else
+        echo "✅ $collection_prefix: $current_version (up-to-date)"
+        echo ""
+      fi
+    else
+      echo "⚠️  $collection_prefix: $current_version (could not check GitHub releases)"
+      echo ""
+    fi
+  fi
+done
+
+echo ""
+echo "=== Check Complete ==="

--- a/dependencies/scripts/update-ansible-requirements.sh
+++ b/dependencies/scripts/update-ansible-requirements.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+set -e
+
+REQUIREMENTS_FILE="/work/requirements.yaml"
+UPDATE_ALL=%v
+COLLECTIONS_TO_UPDATE=(%s)
+
+# Function to check if collection should be updated
+should_update() {
+  local collection=$1
+
+  if [ "$UPDATE_ALL" = "true" ]; then
+    return 0
+  fi
+
+  for col in "${COLLECTIONS_TO_UPDATE[@]}"; do
+    if [ "$col" = "$collection" ]; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+# Function to get latest version from Ansible Galaxy
+get_galaxy_version() {
+  local collection=$1
+  local namespace=$(echo $collection | cut -d'.' -f1)
+  local name=$(echo $collection | cut -d'.' -f2)
+
+  version=$(curl -s "https://galaxy.ansible.com/api/v3/plugin/ansible/content/published/collections/index/${namespace}/${name}/" \
+    | jq -r '.highest_version.version // "unknown"' 2>/dev/null || echo "unknown")
+
+  echo "$version"
+}
+
+# Function to get latest GitHub release version
+get_github_release_version() {
+  local collection_prefix=$1
+  local auth_header=""
+
+  if [ -n "$GITHUB_TOKEN" ]; then
+    auth_header="-H \"Authorization: Bearer $GITHUB_TOKEN\""
+  fi
+
+  version=$(curl -s $auth_header "https://api.github.com/repos/stuttgart-things/ansible/releases" \
+    | jq -r "[.[] | select(.tag_name | contains(\"${collection_prefix}\")) | .tag_name] | first" 2>/dev/null || echo "unknown")
+
+  echo "$version"
+}
+
+echo "Updating Ansible collections..."
+echo ""
+
+# Update Galaxy collections
+yq e '.collections[] | select(.name | test("^[a-z]+\\.[a-z_]+$")) | .name' "$REQUIREMENTS_FILE" | while read -r collection; do
+  if [ -n "$collection" ] && should_update "$collection"; then
+    latest_version=$(get_galaxy_version "$collection")
+
+    if [ "$latest_version" != "unknown" ]; then
+      yq e -i "(.collections[] | select(.name == \"$collection\") | .version) = \"$latest_version\"" "$REQUIREMENTS_FILE"
+      echo "Updated $collection to $latest_version"
+    fi
+  fi
+done
+
+# Update GitHub release collections
+for collection_prefix in sthings-container sthings-baseos sthings-awx sthings-rke; do
+  if should_update "$collection_prefix"; then
+    latest_tag=$(get_github_release_version "$collection_prefix")
+
+    if [ "$latest_tag" != "unknown" ] && [ "$latest_tag" != "null" ]; then
+      new_url="https://github.com/stuttgart-things/ansible/releases/download/${latest_tag}/${latest_tag}.tar.gz"
+      yq e -i "(.collections[] | select(.name | contains(\"$collection_prefix\")) | .name) = \"$new_url\"" "$REQUIREMENTS_FILE"
+      echo "Updated $collection_prefix to $latest_tag"
+    fi
+  fi
+done
+
+echo ""
+echo "Update complete!"


### PR DESCRIPTION
## Summary
Moves the two large embedded bash blobs in `dependencies/ansible.go` into standalone files under `dependencies/scripts/`, loaded via `//go:embed`. Behavior unchanged.

| File | Before | After |
|---|---|---|
| `dependencies/ansible.go` | 314 LOC | **136 LOC** |
| `dependencies/scripts/check-ansible-updates.sh` | (inline) | 100 LOC |
| `dependencies/scripts/update-ansible-requirements.sh` | (inline) | 81 LOC |

The update script preserves the `UPDATE_ALL=%v` / `COLLECTIONS_TO_UPDATE=(%s)` placeholders so `fmt.Sprintf` still wires Go state in at runtime.

Refs #262 — P3 "Split oversized files: `dependencies/ansible.go`". Completes the last remaining item under that checkbox.

## Side benefit
The two scripts are now lintable with shellcheck and editable with proper bash tooling (syntax highlighting, format on save, etc).

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `gofmt -l .` clean
- [x] `dagger functions -m ./dependencies` lists the same 4 functions with identical descriptions
- [ ] End-to-end run of `apply-ansible-updates` against a real requirements.yaml — recommend smoke-testing before merge since the bash blobs aren't exercised by `dagger functions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)