### PR TITLE
fix(crossplane): skip missing CRD schemas in verify Layer 3

### DIFF
--- a/crossplane/verify.go
+++ b/crossplane/verify.go
@@ -14,7 +14,10 @@ import (
 //  3. Layer 2 — each rendered kubernetes.m.crossplane.io Object validated
 //     against the provider-kubernetes CRD schema
 //  4. Layer 3 — each embedded `spec.forProvider.manifest` validated against
-//     the built-in Kubernetes schemas (kubeconform default)
+//     the built-in Kubernetes schemas (kubeconform default). Embedded
+//     manifests whose kind is a CRD the harness has no schema for (e.g. a
+//     Tekton PipelineRun) are skipped via -ignore-missing-schemas rather
+//     than failing the layer — their correctness is owned by the renderer.
 //
 // `crossplane render` is run inside the container via a docker-in-docker
 // sidecar, so function images are pulled and executed without needing a
@@ -150,9 +153,13 @@ for xr in examples/xr*.yaml; do
     fi
 
     # Layer 3: embedded manifests inside spec.forProvider.manifest
+    # Embedded manifests may be arbitrary CRDs (e.g. Tekton PipelineRun) the
+    # harness has no schema for. -ignore-missing-schemas skips those (so they
+    # don't hard-fail the layer) while still strictly validating any embedded
+    # core Kubernetes resources whose schema kubeconform can resolve.
     echo "${RENDERED}" | yq 'select(.kind == "Object") | .spec.forProvider.manifest' > /tmp/embedded.yaml
     if [ -s /tmp/embedded.yaml ]; then
-      if ERR=$(kubeconform -strict /tmp/embedded.yaml 2>&1); then
+      if ERR=$(kubeconform -strict -ignore-missing-schemas /tmp/embedded.yaml 2>&1); then
         status="${status}, embedded-valid"
       else
         status="${status}, embedded-INVALID"


### PR DESCRIPTION
## Problem

`crossplane.Verify` Layer 3 validated each embedded `spec.forProvider.manifest` with `kubeconform -strict`, which hard-fails on any kind without a built-in schema. `cicd/ansible-run` in `crossplane-configurations` is the first Configuration to embed a non-core resource — it wraps a Tekton `PipelineRun` — so verify broke with:

```
/tmp/embedded.yaml - PipelineRun run-ansible-baseos failed validation: could not find schema for PipelineRun
```

This fails identically on `main` of `crossplane-configurations` (not PR-specific).

## Fix

Add `-ignore-missing-schemas` to the Layer 3 `kubeconform` call. Embedded CRDs the harness has no schema for (Tekton, Argo, …) are now **skipped** instead of failing the layer, while embedded **core** Kubernetes resources are still strictly validated (their schema resolves, so `-strict` still applies). The embedded CR's correctness is owned by the renderer — for ansible-run that's the `kcl-tekton-pr` KCL module, which is rendered/validated in its own repo.

Layers 1 (XR↔XRD) and 2 (Object wrapper ↔ provider-kubernetes CRD) are unchanged and remain strict.

## Rollout

After release, bump the `crossplane-module-version` consumed by `call-crossplane-verify.yaml` (default in `github-workflow-templates`, or pinned per-repo) to the new tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)