### PR TITLE
feat(crossplane): add PushPreview for anonymous ttl.sh preview packages

### DIFF
--- a/crossplane/README.md
+++ b/crossplane/README.md
@@ -8,6 +8,7 @@ This module provides Dagger functions for Crossplane package management includin
 - ✅ Package building and validation
 - ✅ Offline three-layer verification (XRD ↔ XR, provider CRD, embedded manifests)
 - ✅ OCI registry publishing with authentication
+- ✅ Anonymous ephemeral preview publishing (ttl.sh) for per-PR packages
 - ✅ Custom package type creation
 - ✅ Multi-registry support (GitHub, Harbor, etc.)
 - ✅ Package dependency management
@@ -51,6 +52,31 @@ dagger call -m crossplane push \
   --registry ghcr.io \
   --destination ghcr.io/stuttgart-things/xplane-registry \
   --progress plain
+```
+
+### Push a Preview Package
+
+Build a single Configuration and push it **anonymously** to an ephemeral
+registry ([ttl.sh](https://ttl.sh) by default) for try-it-on-a-cluster preview
+iteration — e.g. a per-PR preview package in CI. No credentials are required;
+the image is served publicly for the lifetime encoded in the tag (max `24h`).
+The package name is read from `crossplane.yaml`, so you only pass a path prefix
+and a TTL. Returns the ready-to-apply install manifest.
+
+```bash
+dagger call -m crossplane push-preview \
+  --src tests/registry \
+  --prefix stuttgart-things/crossplane-configurations-pr42-abc1234 \
+  --ttl 1h
+```
+
+```yaml
+apiVersion: pkg.crossplane.io/v1
+kind: Configuration
+metadata:
+  name: registry-preview
+spec:
+  package: ttl.sh/stuttgart-things/crossplane-configurations-pr42-abc1234/registry:1h
 ```
 
 ### Verify a Configuration

--- a/crossplane/push_preview.go
+++ b/crossplane/push_preview.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"context"
+	"dagger/crossplane/internal/dagger"
+	"fmt"
+	"strings"
+)
+
+// PushPreview builds a single Crossplane Configuration and pushes it to an
+// ephemeral, anonymous registry (ttl.sh by default) for try-it-on-a-cluster
+// preview iteration — e.g. a per-PR preview package in CI.
+//
+// Unlike Push, it needs no credentials: ttl.sh accepts anonymous pushes and
+// serves the image publicly for the duration encoded in the tag (`:24h`).
+// The package name is read from crossplane.yaml, so the caller only supplies
+// a path prefix and a TTL. It returns the ready-to-apply install manifest
+// (a kind: Configuration whose spec.package points at the pushed ref).
+func (m *Crossplane) PushPreview(
+	ctx context.Context,
+	// a single Configuration directory (containing crossplane.yaml, apis/, examples/)
+	src *dagger.Directory,
+	// +optional
+	// +default="ttl.sh"
+	// registry to push the preview package to (must accept anonymous pushes)
+	registry string,
+	// path prefix under the registry, e.g. "stuttgart-things/crossplane-configurations-pr42-abc1234"
+	prefix string,
+	// +optional
+	// +default="24h"
+	// image lifetime; for ttl.sh this is the tag (max 24h)
+	ttl string,
+) (string, error) {
+
+	if m.XplaneContainer == nil {
+		m.XplaneContainer = m.GetXplaneContainer(ctx)
+	}
+
+	if prefix == "" {
+		return "", fmt.Errorf("prefix is required")
+	}
+
+	// Read the package name from crossplane.yaml so the caller doesn't have to.
+	pkg, err := m.XplaneContainer.
+		WithDirectory("/src", src).
+		WithWorkdir("/src").
+		WithExec([]string{"yq", "-r", ".metadata.name", "crossplane.yaml"}).
+		Stdout(ctx)
+	if err != nil {
+		return "", fmt.Errorf("reading package name from crossplane.yaml: %w", err)
+	}
+	pkg = strings.TrimSpace(pkg)
+	if pkg == "" {
+		return "", fmt.Errorf("crossplane.yaml has no metadata.name")
+	}
+
+	destination := fmt.Sprintf("%s/%s/%s:%s", registry, prefix, pkg, ttl)
+
+	// Build the .xpkg, then push anonymously — no docker config is written, so
+	// no credentials are required (correct for ttl.sh).
+	dirWithPackage := m.Package(ctx, src)
+
+	if _, err := m.XplaneContainer.
+		WithDirectory("/src", dirWithPackage).
+		WithWorkdir("/src").
+		WithExec([]string{"crossplane", "xpkg", "push", destination}).
+		Stdout(ctx); err != nil {
+		return "", fmt.Errorf("pushing %s: %w", destination, err)
+	}
+
+	// The canonical, reusable artifact: a ready-to-apply install manifest.
+	// Presentation (e.g. wrapping in a PR-comment <details> block) is the
+	// caller's concern. The "-preview" suffix avoids clashing with a canonical
+	// install of the same Configuration on a cluster.
+	manifest := fmt.Sprintf(`apiVersion: pkg.crossplane.io/v1
+kind: Configuration
+metadata:
+  name: %s-preview
+spec:
+  package: %s
+`, pkg, destination)
+
+	return manifest, nil
+}


### PR DESCRIPTION
## What

Adds a `PushPreview` function to the `crossplane` module that builds a single Configuration and pushes it **anonymously** to an ephemeral registry (`ttl.sh` by default), returning the ready-to-apply install manifest.

The package name is read from `crossplane.yaml`, so callers pass only a path prefix and a TTL — no credentials required (drops the dummy-`*Secret` dance that `Push` needs).

This lifts the logic currently wrapped by `task push-dev` (gum/Taskfile/curl bootstrap) into the module, so the per-PR `preview` job in `crossplane-configurations` can call it directly — mirroring the existing `Verify` integration.

## Signature

```go
func (m *Crossplane) PushPreview(
    ctx context.Context,
    src *dagger.Directory,        // single Configuration dir
    registry string,             // +default="ttl.sh"
    prefix string,               // e.g. stuttgart-things/crossplane-configurations-pr42-abc1234
    ttl string,                  // +default="24h"
) (string, error)               // install-manifest YAML
```

## Verification (acceptance criteria)

- [x] Pushes a built package to `ttl.sh/<prefix>/<pkg>:<ttl>` anonymously
- [x] Package name read from `crossplane.yaml` (not passed in)
- [x] Returns the install manifest YAML
- [x] Verified locally:

```
dagger call -m ./crossplane push-preview --src ./tests/registry \
  --prefix stuttgart-things/dagger-test-issue289 --ttl 1h
```
emits:
```yaml
apiVersion: pkg.crossplane.io/v1
kind: Configuration
metadata:
  name: registry-preview
spec:
  package: ttl.sh/stuttgart-things/dagger-test-issue289/registry:1h
```
and the pushed image is anonymously pullable (`docker manifest inspect` succeeds).

`go build`, `go vet`, and `golangci-lint run` all pass.

## Follow-up (cross-repo, not in this PR)

Per the issue's rollout: after this merges and a new `crossplane` tag is cut, bump the pin in `crossplane-configurations` and rewrite the `preview` job to call `push-preview` directly (drop the `task`/`gum`/`curl` bootstrap).

Closes #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)