### PR TITLE
fix(crossplane): harden crossplane CLI install against flaky downloads

### DIFF
--- a/crossplane/container.go
+++ b/crossplane/container.go
@@ -10,7 +10,76 @@ const (
 	// openapi2jsonschema.py is pinned to the same kubeconform release so the
 	// script and binary evolve together.
 	openapi2jsonschemaURL = "https://raw.githubusercontent.com/yannh/kubeconform/" + kubeconformVersion + "/scripts/openapi2jsonschema.py"
+
+	// crossplaneChannel selects the crossplane (crank) CLI release channel.
+	// The channel's `current` marker is resolved to an exact version at
+	// image-build time and the binary is then pulled from the immutable
+	// versioned path so the download and its checksum line up. Pin to an
+	// exact version (e.g. "v1.20.0") here if reproducibility ever matters
+	// more than tracking the latest stable release.
+	crossplaneChannel = "stable"
 )
+
+// crossplaneInstall downloads and installs the crossplane (crank) CLI with
+// integrity checks. A bare `curl … --output crossplane` silently writes
+// whatever the CDN returns — a truncated stream, a rate-limit page, or an
+// HTML 4xx body — to /usr/bin/crossplane, which then executes as a shell
+// script and dies with "line 2: syntax error: unexpected newline" (the
+// classic "no ELF magic, fall back to /bin/sh" signature). This installer
+// instead: (1) uses curl -f + --retry so HTTP errors and transient blips
+// fail/retry rather than producing a bad file; (2) verifies the published
+// SHA256 when present (catches truncation and HTML-200 bodies); (3) executes
+// the installed binary as a final sanity gate; and (4) retries the whole
+// install on any failure, so a single corrupt fetch can't poison the image.
+const crossplaneInstall = `#!/bin/sh
+set -u
+
+CHANNEL="${CROSSPLANE_CHANNEL:-stable}"
+BASE="https://releases.crossplane.io/${CHANNEL}"
+
+# Resolve the channel to an exact version so the binary and its checksum are
+# fetched from the same immutable path.
+VERSION=$(curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors "${BASE}/current/version" | tr -d '[:space:]')
+if [ -z "${VERSION}" ]; then
+  echo "crossplane install: could not resolve ${CHANNEL} version" >&2
+  exit 1
+fi
+URL="${BASE}/${VERSION}/bin/linux_amd64/crank"
+echo "crossplane install: ${CHANNEL} ${VERSION}"
+
+i=1
+while [ "${i}" -le 3 ]; do
+  rm -f /tmp/crossplane /tmp/crossplane.sha256
+  if curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors "${URL}" -o /tmp/crossplane; then
+    # Integrity: verify the published checksum when the bucket serves one.
+    # A truncated body or an HTML error page won't match, so a bad download
+    # is rejected before it can be installed.
+    if curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors "${URL}.sha256" -o /tmp/crossplane.sha256 2>/dev/null \
+         && [ -s /tmp/crossplane.sha256 ]; then
+      want=$(awk '{print $1}' /tmp/crossplane.sha256)
+      got=$(sha256sum /tmp/crossplane | awk '{print $1}')
+      if [ "${want}" != "${got}" ]; then
+        echo "crossplane install: checksum mismatch (want ${want}, got ${got}), attempt ${i}" >&2
+        i=$((i + 1)); sleep 2; continue
+      fi
+    fi
+    install -m 0755 /tmp/crossplane /usr/bin/crossplane
+    # Final sanity: a real binary runs; an HTML/truncated file does not. This
+    # also covers the case where the bucket served no .sha256 to verify.
+    if crossplane version --client >/dev/null 2>&1; then
+      echo "crossplane install: ok"
+      exit 0
+    fi
+    echo "crossplane install: installed binary failed to run, attempt ${i}" >&2
+  else
+    echo "crossplane install: download failed, attempt ${i}" >&2
+  fi
+  i=$((i + 1)); sleep 2
+done
+
+echo "crossplane install: failed after retries" >&2
+exit 1
+`
 
 // GetXplaneContainer returns the default image for Crossplane with crossplane and kcl2xrd installed
 func (m *Crossplane) GetXplaneContainer(ctx context.Context) *dagger.Container {
@@ -19,10 +88,12 @@ func (m *Crossplane) GetXplaneContainer(ctx context.Context) *dagger.Container {
 		// Install dependencies. python + py3-pyyaml + crane back the Verify pipeline
 		// (CRD schema extraction + provider image export); curl + yq are also used elsewhere.
 		WithExec([]string{"apk", "add", "curl", "yq", "crane", "python-3.13", "py3-pyyaml"}).
-		// Install crossplane
-		WithExec([]string{"curl", "https://releases.crossplane.io/stable/current/bin/linux_amd64/crank", "--output", "crossplane"}).
-		WithExec([]string{"mv", "crossplane", "/usr/bin/crossplane"}).
-		WithExec([]string{"chmod", "+x", "/usr/bin/crossplane"}).
+		// Install crossplane (crank) via an integrity-checked installer. A bare
+		// download writes any CDN error/truncation straight to the binary, which
+		// then dies as a "line 2: syntax error" the next time it is invoked.
+		WithEnvVariable("CROSSPLANE_CHANNEL", crossplaneChannel).
+		WithNewFile("/tmp/install-crossplane.sh", crossplaneInstall).
+		WithExec([]string{"sh", "/tmp/install-crossplane.sh"}).
 		// Install kcl2xrd
 		WithExec([]string{"curl", "-L", "https://github.com/ggkhrmv/kcl2xrd/releases/download/v0.8.0/kcl2xrd-linux-amd64", "--output", "kcl2xrd"}).
 		WithExec([]string{"mv", "kcl2xrd", "/usr/bin/kcl2xrd"}).


### PR DESCRIPTION
## Problem

The crossplane `Verify` function intermittently fails with:

```
/usr/bin/crossplane: line 2: syntax error: unexpected newline
```

across both `xpkg build` and every `crossplane render` step, on Configurations whose YAML is unchanged. This broke two consecutive PRs in `stuttgart-things/crossplane-configurations` (each passed on a plain re-run), and is non-deterministic so it keeps recurring.

### Root cause

In `crossplane/container.go`, the crossplane (crank) CLI was installed with a bare download:

```go
WithExec([]string{"curl", "https://releases.crossplane.io/stable/current/bin/linux_amd64/crank", "--output", "crossplane"}).
WithExec([]string{"mv", "crossplane", "/usr/bin/crossplane"}).
WithExec([]string{"chmod", "+x", "/usr/bin/crossplane"}).
```

That `curl` had **no `-f`** (HTTP 4xx/5xx error / rate-limit pages get written as the "binary"), **no `-L`/retry**, and **no integrity check**. When the CDN hiccupped and returned a truncated stream or HTML body, it landed in `/usr/bin/crossplane`; the kernel found no ELF magic, fell back to `/bin/sh`, and every later invocation died on line 2. This matches the issue's "no ELF magic → fall back to sh" diagnosis, and explains why the XRD-valid (pure YAML) check still passed while only the binary-invoking steps failed.

## Fix

Replaced the three download steps with an integrity-checked installer (`crossplaneInstall`) that combines all three remedies suggested in the issue:

1. **Pin to an exact version** — resolves `stable/current/version`, then downloads from the immutable `stable/<version>/...` path so the binary and its checksum come from the same place.
2. **`curl -f --retry`** — HTTP errors and transient blips fail/retry instead of writing a bad body.
3. **SHA256 verification** when the bucket serves a `.sha256` (catches truncation and HTML-200 bodies).
4. **Execute sanity gate** — `crossplane version --client` must run, catching any non-ELF file even when no checksum is published.
5. **Retry the whole install** (3 attempts) so a single corrupt fetch can't poison the cached image layer.

## Notes / caveats

- Could not run `go build` or `dagger call` in the build environment — the generated `internal/dagger` client is gitignored and no dagger CLI is available. `gofmt` is clean and the change only uses Dagger APIs already used elsewhere in the module (`WithNewFile`, `WithEnvVariable`).
- The script relies on busybox tools (`sha256sum`, `awk`, `tr`, `install`, `sleep`) which ship with `wolfi-base`.
- Kept the channel as `stable` (resolved to the current version) rather than hard-coding a tag, since outbound access to `releases.crossplane.io` is blocked in the build environment. The `crossplaneChannel` const is documented so it can be pinned to an exact version later if desired.

Related: #277

https://claude.ai/code/session_014B2TMsGA71X7vM875T5LJ3

---
_Generated by [Claude Code](https://claude.ai/code/session_014B2TMsGA71X7vM875T5LJ3)_