### PR TITLE
fix(linting): pin pre-commit base image to alpine:3.21

### DIFF
--- a/linting/container.go
+++ b/linting/container.go
@@ -6,7 +6,10 @@ import (
 
 func (m *Linting) container() *dagger.Container {
 	if m.BaseImage == "" {
-		m.BaseImage = "alpine"
+		// Pin the base image (tag, not :latest) so pre-commit runs are
+		// reproducible and don't depend on docker.io resolving a mutable
+		// alpine:latest on every run. Overridable via --base-image. See #288.
+		m.BaseImage = "alpine:3.21"
 	}
 
 	ctr := dag.Container().From(m.BaseImage)


### PR DESCRIPTION
## What

Pin the `linting` module's default base image from the unpinned `alpine` (→ mutable `docker.io/library/alpine:latest`) to **`alpine:3.21`**.

## Why

Resolves #288. Every `runPreCommit` resolved `docker.io/library/alpine:latest` fresh, so lint results depended on docker.io reachability / anonymous-pull rate limits rather than the code being linted. Observed CI flake (crossplane-configurations PR #10):

```
Container.from(address: "alpine") → resolving docker.io/library/alpine:latest ERROR
! failed to do request: Head ".../library/alpine/manifests/latest": dial tcp ...: i/o timeout
```

`:latest` is also mutable, so runs weren't reproducible and the layer cache was invalidated whenever upstream `alpine` moved.

## Change

- `linting/container.go`: default `m.BaseImage` → `alpine:3.21` (tag, not `latest`).
- `m.BaseImage` stays overridable via `--base-image` so callers can point at an internal mirror (acceptance criterion 3).

## Verification

Ran `dagger -m ./linting call lint-yaml` locally against the pinned base — the full `apk add` (yamllint, shellcheck, ruby, py3-pip, git, docker-cli, jq, …) + `gem install mdl` + `pip3 install pre-commit detect-secrets` pipeline installs cleanly on `alpine:3.21` and yamllint runs.

## Acceptance

- [x] Default base image is pinned (tag), not `latest`.
- [x] `runPreCommit` no longer depends on a mutable docker.io tag.
- [x] Tool list still installs cleanly on the pinned base.

## Follow-up (out of scope)

The issue notes the same `From("alpine")`/`:latest` pattern is worth auditing elsewhere. Found in: `docker/mirror.go`, `go/{main,container,build}.go`, `hugo/merge.go`, `homerun/main.go`, `sops/config.go`. Left for a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)