### PR TITLE
fix: pin unpinned alpine/redis base images in docker, sops, homerun (#288 follow-up)

### DIFF
--- a/docker/mirror.go
+++ b/docker/mirror.go
@@ -134,7 +134,7 @@ fi
 
 	// Get current timestamp
 	timestamp, err := dag.Container().
-		From("alpine:latest").
+		From("alpine:3.21").
 		WithExec([]string{"date", "+%Y-%m-%d %H:%M:%S UTC"}).
 		Stdout(ctx)
 	if err != nil {
@@ -179,7 +179,7 @@ Usage:
 
 	// STEP 5: Create zip archive with summary
 	zipContainer := dag.Container().
-		From("alpine:latest").
+		From("alpine:3.21").
 		WithExec([]string{"apk", "add", "--no-cache", "zip"}).
 		WithDirectory("/work", mirrorDir).
 		WithWorkdir("/work").

--- a/homerun/main.go
+++ b/homerun/main.go
@@ -96,7 +96,7 @@ func (m *Homerun) RedisCli(
 	}
 
 	return dag.Container().
-		From("redis:alpine").
+		From("redis:7.4-alpine").
 		WithServiceBinding("redis", redis).
 		WithEntrypoint(args).
 		Terminal()
@@ -124,7 +124,7 @@ func (m *Homerun) TestRedisConnection(
 	}
 
 	return dag.Container().
-		From("alpine:latest").
+		From("alpine:3.21").
 		WithServiceBinding("redis", redis).
 		WithExec(cmd).
 		Stdout(ctx)

--- a/sops/config.go
+++ b/sops/config.go
@@ -44,7 +44,7 @@ creation_rules:
 `, strings.Join(rules, "\n"))
 
 	ctr := dag.Container().
-		From("alpine:latest").
+		From("alpine:3.21").
 		WithNewFile("/tmp/.sops.yaml", configContent)
 
 	return ctr.File("/tmp/.sops.yaml"), nil


### PR DESCRIPTION
## What

Follow-up to #292 (which pinned the `linting` module). Pins the remaining unpinned `From("alpine:latest")` / `From("redis:alpine")` occurrences, per the closing note in #288 ("Same pattern likely worth auditing in other modules").

| Module | Before | After |
|--------|--------|-------|
| `docker/mirror.go` (timestamp + zip helpers) | `alpine:latest` | `alpine:3.21` |
| `sops/config.go` (config generation) | `alpine:latest` | `alpine:3.21` |
| `homerun/main.go` (TestRedisConnection) | `alpine:latest` | `alpine:3.21` |
| `homerun/main.go` (RedisCLI) | `redis:alpine` | `redis:7.4-alpine` |

## Why

Same failure mode as #288: every run resolved a mutable docker.io `:latest` tag fresh, making results depend on docker.io reachability / anonymous-pull rate limits and making runs non-reproducible.

## Excluded: hugo

`hugo/merge.go` also has an `alpine:latest`, but the `hugo` module currently **fails its `dagger functions` lint on `main`** due to a pre-existing OpenTelemetry version skew in its generated `internal/telemetry` client (`*collectLogProcessor` implements the old `Enabled(ctx, Record)` signature; the resolved `otel/sdk/log` wants `Enabled(ctx, EnabledParameters)`). This is unrelated to base-image pinning and is not surfaced on `main` only because the hugo lint job is skipped unless the module changes. Pinning hugo is deferred to a dedicated PR that also regenerates/fixes the client, so this PR stays green.

## Excluded (intentionally not changed)

- **`go/` module**: `+default="alpine"` is a *variant suffix* on an already-pinned `golang:<version>-alpine`; the Go version is pinned, so it's not a `:latest` flake.
- **`homerun` RedisService** already pins `redis/redis-stack-server:7.2.0-v18`.
- **`docker` mirror `BaseImage`** already defaults to the pinned `python:3.13.7-alpine`.

## Verification

- `dagger -m ./sops call generate-sops-config …` → builds on `alpine:3.21`.
- `dagger -m ./homerun call test-redis-connection` → `apk add redis` from v3.21 repos + `redis-cli ping` → `PONG`.
- `dagger core container from --address redis:7.4-alpine …` → `redis-cli 7.4.9` (tag resolves).
- `docker` mirror uses the same `apk add` pattern proven above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)