### PR TITLE
fix(crossplane): pin crank CLI to v2.2.2 (render-compatible)

### DIFF
--- a/crossplane/container.go
+++ b/crossplane/container.go
@@ -12,12 +12,29 @@ const (
 	openapi2jsonschemaURL = "https://raw.githubusercontent.com/yannh/kubeconform/" + kubeconformVersion + "/scripts/openapi2jsonschema.py"
 
 	// crossplaneChannel selects the crossplane (crank) CLI release channel.
-	// The channel's `current` marker is resolved to an exact version at
-	// image-build time and the binary is then pulled from the immutable
-	// versioned path so the download and its checksum line up. Pin to an
-	// exact version (e.g. "v1.20.0") here if reproducibility ever matters
-	// more than tracking the latest stable release.
+	// Used only as the bucket path and as the fallback when crossplaneVersion
+	// is empty.
 	crossplaneChannel = "stable"
+
+	// crossplaneVersion pins the crank CLI to an exact release instead of
+	// tracking the channel's floating `current` marker.
+	//
+	// Why this is pinned: crank v2.3.0 changed `crossplane render` to run the
+	// pipeline by re-exec'ing `crossplane internal render` inside the function
+	// Docker container. The crossplane-contrib function images still ship an
+	// older crossplane binary that has no `internal` subcommand, so every
+	// render fails with:
+	//
+	//   cannot run crossplane internal render in Docker: container exited with
+	//   status 1: crossplane: error: unexpected argument internal
+	//
+	// When `current` advanced to v2.3.0 this silently broke Verify for every
+	// function-based Configuration (it tracked the channel, so the same module
+	// tag started failing without any code change). v2.2.2 is the latest
+	// release whose render still runs functions the compatible way. Bump this
+	// once the function images (or a later crank) resolve the skew.
+	// See stuttgart-things/dagger#295.
+	crossplaneVersion = "v2.2.2"
 )
 
 // crossplaneInstall downloads and installs the crossplane (crank) CLI with
@@ -37,9 +54,15 @@ set -u
 CHANNEL="${CROSSPLANE_CHANNEL:-stable}"
 BASE="https://releases.crossplane.io/${CHANNEL}"
 
-# Resolve the channel to an exact version so the binary and its checksum are
-# fetched from the same immutable path.
-VERSION=$(curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors "${BASE}/current/version" | tr -d '[:space:]')
+# Prefer an explicit pin (CROSSPLANE_VERSION). Only fall back to the channel's
+# floating 'current' marker when no pin is set — tracking 'current' is what let
+# crank v2.3.0 silently break render (see crossplaneVersion comment above).
+VERSION="${CROSSPLANE_VERSION:-}"
+if [ -z "${VERSION}" ]; then
+  # Resolve the channel to an exact version so the binary and its checksum are
+  # fetched from the same immutable path.
+  VERSION=$(curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors "${BASE}/current/version" | tr -d '[:space:]')
+fi
 if [ -z "${VERSION}" ]; then
   echo "crossplane install: could not resolve ${CHANNEL} version" >&2
   exit 1
@@ -92,6 +115,7 @@ func (m *Crossplane) GetXplaneContainer(ctx context.Context) *dagger.Container {
 		// download writes any CDN error/truncation straight to the binary, which
 		// then dies as a "line 2: syntax error" the next time it is invoked.
 		WithEnvVariable("CROSSPLANE_CHANNEL", crossplaneChannel).
+		WithEnvVariable("CROSSPLANE_VERSION", crossplaneVersion).
 		WithNewFile("/tmp/install-crossplane.sh", crossplaneInstall).
 		WithExec([]string{"sh", "/tmp/install-crossplane.sh"}).
 		// Install kcl2xrd


### PR DESCRIPTION
Fixes #295

## Problem

The `crossplane` module's Verify render layer started failing for **every** function-based Configuration:

```
crossplane: error: cannot render composite resource: cannot run crossplane internal render
in Docker: container exited with status 1: crossplane: error: unexpected argument internal
```

`xpkg build` and XRD validation still pass — only `crossplane render` fails.

## Root cause

`container.go` installed crank from the **`stable` channel's floating `current` marker**, resolved at image-build time. crank **v2.3.0** changed `crossplane render` to re-exec `crossplane internal render` inside the function Docker container, but the crossplane-contrib function images ship an older crossplane without the `internal` subcommand. When `current` advanced to v2.3.0, render broke **with no code change** — the same module tag flipped green → red (consumer reproduced this on an unchanged Configuration across 2026-06-04 → 06-07).

## Bisection

Rendered the merged `bootstrap/vault-auth` example with each crank:

| crank | render |
|---|---|
| v2.2.1 | ✅ |
| v2.2.2 | ✅ |
| **v2.3.0** | ❌ (this error) |

## Fix

Pin crank to **v2.2.2** (latest release whose render still runs functions compatibly) via a new `CROSSPLANE_VERSION` env honored by the installer. The channel `current` resolution stays as a fallback when no pin is set, so behaviour is unchanged except for the pin. Bump the pin once the function images (or a later crank) resolve the skew.

`go build` / `go vet` / `gofmt` clean.

## Follow-up (consumer side)

After this merges and a module release is tagged, bump `CROSSPLANE_MODULE_VERSION` in `stuttgart-things/crossplane-configurations/.github/workflows/verify.yaml` to pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)