### PR TITLE
fix(crossplane): tolerate crossplane bucket's mismatched crank.sha256

### DIFF
--- a/crossplane/container.go
+++ b/crossplane/container.go
@@ -74,21 +74,27 @@ i=1
 while [ "${i}" -le 3 ]; do
   rm -f /tmp/crossplane /tmp/crossplane.sha256
   if curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors "${URL}" -o /tmp/crossplane; then
-    # Integrity: verify the published checksum when the bucket serves one.
-    # A truncated body or an HTML error page won't match, so a bad download
-    # is rejected before it can be installed.
+    # Integrity: compare against the published checksum when the bucket serves
+    # one. NOTE: the crossplane release bucket currently serves crank.sha256
+    # files that do NOT match the served binaries (observed for every version
+    # via CloudFront, 2026-06). A mismatch is therefore treated as a WARNING,
+    # not a hard failure: we fall through to the run-check below, which is the
+    # authoritative gate. A truncated body or HTML error page cannot execute,
+    # so it still fails the run-check and retries; only a valid binary with a
+    # stale/wrong published checksum is allowed through.
+    # See stuttgart-things/dagger#295.
     if curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors "${URL}.sha256" -o /tmp/crossplane.sha256 2>/dev/null \
          && [ -s /tmp/crossplane.sha256 ]; then
       want=$(awk '{print $1}' /tmp/crossplane.sha256)
       got=$(sha256sum /tmp/crossplane | awk '{print $1}')
       if [ "${want}" != "${got}" ]; then
-        echo "crossplane install: checksum mismatch (want ${want}, got ${got}), attempt ${i}" >&2
-        i=$((i + 1)); sleep 2; continue
+        echo "crossplane install: WARNING checksum mismatch (want ${want}, got ${got}); relying on run-check" >&2
       fi
     fi
     install -m 0755 /tmp/crossplane /usr/bin/crossplane
-    # Final sanity: a real binary runs; an HTML/truncated file does not. This
-    # also covers the case where the bucket served no .sha256 to verify.
+    # Authoritative gate: a real binary runs; an HTML/truncated/corrupt file
+    # does not. This also covers the case where the bucket served no .sha256
+    # (or a wrong one) to verify.
     if crossplane version --client >/dev/null 2>&1; then
       echo "crossplane install: ok"
       exit 0


### PR DESCRIPTION
Refs #295. Follow-up to #296 (the v2.2.2 render-compat pin).

## Problem

v0.117.0 ships the hardened installer (#291), which **hard-fails** when the published `crank.sha256` doesn't match the downloaded binary. The crossplane release bucket currently serves `crank.sha256` files that match **no** binary:

| version | published .sha256 | actual binary sha256 |
|---|---|---|
| v2.2.1 | `58686ed7e548…` | `9a1985e5c132…` ❌ |
| v2.2.2 | `69769f6922e0…` | `494361eb20da…` ❌ |
| v2.3.0 | `96d6d9529cac…` | `f486c86df39a…` ❌ |

Served raw (no `content-encoding`; `--compressed` yields the same hash) via CloudFront/S3, and the binaries themselves are valid (they run and render). So the strict check blocks install of **every** version:

```
crossplane install: checksum mismatch (want 69769f…, got 494361…)
crossplane install: failed after retries
```

This never surfaced before because the consumer still pins **v0.116.0**, which predates #291 and used a bare download.

## Fix

Downgrade a checksum mismatch from **fatal** to a **warning**, and fall through to the run-check (`crossplane version --client`) — the authoritative gate. A truncated/HTML/corrupt download cannot execute, so it still fails the run-check and retries; the anti-corruption intent of #291 is preserved. Only a valid binary with a stale/wrong *published* checksum is now allowed through.

## Validation

Locally, with this change the module installs crank v2.2.2 and passes `xpkg build` + XRD validation against `bootstrap/vault-auth`. (The render step needs CI's docker-in-docker networking to exercise fully; verified separately that v2.2.2 `crossplane render` produces correct output on the host.) `go build` / `go vet` / `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)