### PR TITLE
refactor: salvage perf/cleanup from #152

### DIFF
--- a/git/container.go
+++ b/git/container.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 
 	"dagger/git/internal/dagger"
 )
@@ -19,15 +20,21 @@ func (m *Git) container(
 	ghVersion := "2.82.1"
 	ghURL := "https://github.com/cli/cli/releases/download/v" + ghVersion + "/gh_" + ghVersion + "_linux_amd64.tar.gz"
 
+	// Combine multiple shell commands into a single script for efficiency
+	// This reduces container layer overhead and speeds up container creation
+	installGhScript := fmt.Sprintf(`
+wget -O /tmp/gh.tar.gz %s && \
+tar -xzf /tmp/gh.tar.gz -C /tmp && \
+mkdir -p /usr/local/bin && \
+cp /tmp/gh_%s_linux_amd64/bin/gh /usr/local/bin/gh && \
+chmod +x /usr/local/bin/gh && \
+rm -rf /tmp/gh.tar.gz /tmp/gh_%s_linux_amd64
+`, ghURL, ghVersion, ghVersion)
+
 	ctr := dag.Container().
 		From(m.BaseImage).
 		WithExec([]string{"apk", "add", "--no-cache", "git", "wget"}).
-		WithExec([]string{"sh", "-c", "wget -O /tmp/gh.tar.gz " + ghURL}).
-		WithExec([]string{"sh", "-c", "tar -xzf /tmp/gh.tar.gz -C /tmp"}).
-		WithExec([]string{"sh", "-c", "mkdir -p /usr/local/bin"}).
-		WithExec([]string{"sh", "-c", "cp /tmp/gh_" + ghVersion + "_linux_amd64/bin/gh /usr/local/bin/gh"}).
-		WithExec([]string{"sh", "-c", "chmod +x /usr/local/bin/gh"}).
-		WithExec([]string{"sh", "-c", "rm -rf /tmp/gh.tar.gz /tmp/gh_" + ghVersion + "_linux_amd64"}).
+		WithExec([]string{"sh", "-c", installGhScript}).
 		WithEntrypoint([]string{"git"})
 
 	return ctr, nil

--- a/linting/container.go
+++ b/linting/container.go
@@ -41,19 +41,11 @@ func (m *Linting) container() *dagger.Container {
 			"&& chmod +x /usr/local/bin/hadolint",
 	})
 
+	// Combine gem and pip installs into a single shell command for efficiency
+	// This reduces container layer overhead
 	ctr = ctr.WithExec([]string{
-		"gem",
-		"install",
-		"mdl",
-		"--no-document",
-	})
-
-	ctr = ctr.WithExec([]string{
-		"pip3",
-		"install",
-		"--break-system-packages",
-		"pre-commit",
-		"detect-secrets",
+		"sh", "-c",
+		"gem install mdl --no-document && pip3 install --break-system-packages --no-cache-dir pre-commit detect-secrets",
 	})
 
 	return ctr

--- a/templating/file.go
+++ b/templating/file.go
@@ -50,23 +50,11 @@ func (m *Templating) RenderFromFile(
 
 	// Check if dataFile is an HTTPS URL
 	if strings.HasPrefix(dataFile, "https://") {
-		// Download the data file from URL
-		resp, err := http.Get(dataFile)
+		// Download the data file from URL via helper (closes the body before returning)
+		fileContent, err = downloadURLContent(dataFile)
 		if err != nil {
 			return nil, fmt.Errorf("failed to download data file from %s: %w", dataFile, err)
 		}
-		defer resp.Body.Close()
-
-		if resp.StatusCode != http.StatusOK {
-			return nil, fmt.Errorf("failed to download data file from %s: status %d", dataFile, resp.StatusCode)
-		}
-
-		// Read the content
-		bodyBytes, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read data file from %s: %w", dataFile, err)
-		}
-		fileContent = string(bodyBytes)
 	} else {
 		// Read the data file from local directory
 		fileContent, err = src.File(dataFile).Contents(ctx)
@@ -127,23 +115,12 @@ func (m *Templating) RenderFromFile(
 
 		// Check if it's an HTTPS URL
 		if strings.HasPrefix(tmplPath, "https://") {
-			// Download template from URL
-			resp, err := http.Get(tmplPath)
+			// Download template from URL via helper so the body is closed
+			// each iteration instead of deferring inside the loop.
+			tmplContent, err = downloadURLContent(tmplPath)
 			if err != nil {
 				return nil, fmt.Errorf("failed to download template from %s: %w", tmplPath, err)
 			}
-			defer resp.Body.Close()
-
-			if resp.StatusCode != http.StatusOK {
-				return nil, fmt.Errorf("failed to download template from %s: status %d", tmplPath, resp.StatusCode)
-			}
-
-			// Read the content
-			bodyBytes, err := io.ReadAll(resp.Body)
-			if err != nil {
-				return nil, fmt.Errorf("failed to read template from %s: %w", tmplPath, err)
-			}
-			tmplContent = string(bodyBytes)
 		} else {
 			// Read from local directory
 			tmplContent, err = src.File(tmplPath).Contents(ctx)
@@ -189,4 +166,27 @@ func (m *Templating) RenderFromFile(
 
 	// Return the directory with rendered templates
 	return container.Directory("/output"), nil
+}
+
+// downloadURLContent downloads content from a URL and returns it as a string,
+// closing the response body before returning. Using this helper instead of an
+// inline http.Get + deferred Close avoids leaking response bodies when called
+// from inside a loop.
+func downloadURLContent(url string) (string, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("status %d", resp.StatusCode)
+	}
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	return string(bodyBytes), nil
 }

--- a/templating/string.go
+++ b/templating/string.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"dagger/templating/internal/dagger"
 	"fmt"
-	"io"
-	"net/http"
 	"strings"
 	"text/template"
 
@@ -105,23 +103,12 @@ func (m *Templating) Render(
 
 		// Check if it's an HTTPS URL
 		if strings.HasPrefix(tmplPath, "https://") {
-			// Download template from URL
-			resp, err := http.Get(tmplPath)
+			// Download template from URL via helper so the body is closed
+			// each iteration instead of deferring inside the loop.
+			tmplContent, err = downloadURLContent(tmplPath)
 			if err != nil {
 				return nil, fmt.Errorf("failed to download template from %s: %w", tmplPath, err)
 			}
-			defer resp.Body.Close()
-
-			if resp.StatusCode != http.StatusOK {
-				return nil, fmt.Errorf("failed to download template from %s: status %d", tmplPath, resp.StatusCode)
-			}
-
-			// Read the content
-			bodyBytes, err := io.ReadAll(resp.Body)
-			if err != nil {
-				return nil, fmt.Errorf("failed to read template from %s: %w", tmplPath, err)
-			}
-			tmplContent = string(bodyBytes)
 		} else {
 			// Read from local directory
 			tmplContent, err = src.File(tmplPath).Contents(ctx)


### PR DESCRIPTION
Salvages the worthwhile source-level changes from the stale draft #152 and re-applies them against current `main`. #152 itself can't merge — it's `CONFLICTING/DIRTY`, ~7 months old, and most of its −2372 diff is `go.mod`/`go.sum` churn made obsolete by the v0.21.7 upgrade and the otel/dep bumps.

## Included
- **Resource-leak fixes (defer-in-loop)** — `hugo/helpers.go`, `templating/file.go`, `templating/string.go`. The `defer resp.Body.Close()` lived inside a loop, so bodies stayed open until the loop returned. Extracted per-item helpers (`downloadSingleImage`, `downloadURLContent`) that close each iteration.
- **WithExec consolidation** — `git/container.go`, `linting/container.go`. Collapse chained shell `WithExec` steps into a single script to cut container layers.

## Deliberately excluded
- **helm container caching** (`cachedContainer` struct field) — held for review. Dagger module structs aren't reliably persistent across calls, and the engine already content-caches operations; this needs a real look, not a rubber stamp.
- **kcl / helm WithExec changes** — already done or superseded on current `main` (kcl already does the combined `apt-get`; helm's duplicate `apk add` is already gone).
- **`ansible/container.go` `From()` default** and **`go/test.go`** (drops the separate coverage run, changing returned output) — behavior changes, out of scope for a cleanup PR.

## Verification
Each touched module verified locally with `go build`, `go vet`, `gofmt`, and `dagger functions`.

Supersedes the salvageable portion of #152.

🤖 Generated with [Claude Code](https://claude.com/claude-code)