### PR TITLE
fix(packer): use POST for proxmox template rename

### DIFF
--- a/packer/proxmox.go
+++ b/packer/proxmox.go
@@ -122,7 +122,9 @@ func (m *Packer) Proxmoxoperation(
 		if target == "" {
 			return "", fmt.Errorf("target (new VM name) must be specified for rename")
 		}
-		return c.do(ctx, http.MethodPut,
+		// POST (async) on the qemu config endpoint: PVE returns
+		// "501 Method 'PUT ...' not implemented" for PUT here.
+		return c.do(ctx, http.MethodPost,
 			fmt.Sprintf("/nodes/%s/qemu/%s/config", node, vmid),
 			url.Values{"name": {target}})
 


### PR DESCRIPTION
## Problem
`Proxmoxoperation --operation rename` fails against Proxmox VE:

```
proxmox PUT /nodes/ul-pve01/qemu/144/config: 501 Method 'PUT /api2/json/nodes/ul-pve01/qemu/144/config' not implemented
```

The qemu config endpoint doesn't implement `PUT` — it implements `POST` (async, returns a task UPID).

## Fix
`rename` now issues `POST` instead of `PUT` (one-line change in `proxmox.go`). `move` (migrate, POST) and `delete` (DELETE) were already correct.

## Verified
Renamed template 144 on `ul-pve01` via the same POST call (`{"data":"UPID:ul-pve01:...:qmconfig:144:..."}`, GET confirms `name=ubuntu26-base-os`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)