### PR TITLE
fix(ansible): derive galaxy.yml metadata from collection.yaml

### DIFF
--- a/ansible/collection.go
+++ b/ansible/collection.go
@@ -33,8 +33,6 @@ func (m *Ansible) InitCollection(
 	ctx context.Context,
 	src *dagger.Directory) (*CollectionResult, error) {
 
-	metaInformation := make(map[string]interface{})
-
 	allCollectionFiles, err := src.Entries(ctx)
 	if err != nil {
 		fmt.Println("ERROR GETTING ENTRIES: ", err)
@@ -49,10 +47,7 @@ func (m *Ansible) InitCollection(
 		playbooks, vars, modules, templates, meta, requirements = collections.ProcessCollectionFile([]byte(content), playbooks, vars, modules, templates, meta, requirements)
 	}
 
-	metaInformation["namespace"] = meta["namespace"]
-	metaInformation["name"] = meta["name"]
-	metaInformation["authors"] = meta["authors"]
-	metaInformation["version"] = collections.GenerateSemanticVersion()
+	metaInformation := collections.BuildGalaxyMeta(meta, collections.GenerateSemanticVersion())
 
 	collectionContentDir := collectionWorkDir + "/" + metaInformation["namespace"].(string) + "/" + metaInformation["name"].(string)
 

--- a/ansible/collections/meta.go
+++ b/ansible/collections/meta.go
@@ -14,22 +14,54 @@ namespace: {{ .namespace }}
 name: {{ .name }}
 version: {{ .version }}
 readme: README.md
-authors:
-- your name <example@domain.com>
+authors: {{ .authors }}
 
 ### OPTIONAL
-description: your collection description
-license:
-- GPL-2.0-or-later
-license_file: ''
-tags: []
+description: {{ .description }}
+license: {{ .license }}
+license_file: '{{ .license_file }}'
+tags: {{ .tags }}
 dependencies: {}
-repository: http://example.com/repository
-documentation: http://docs.example.com
-homepage: http://example.com
-issues: http://example.com/issue/tracker
+repository: {{ .repository }}
+documentation: {{ .documentation }}
+homepage: {{ .homepage }}
+issues: {{ .issues }}
 build_ignore: []
 `
+
+// FALLBACKS FOR GALAXY FIELDS A COLLECTION DOES NOT DECLARE ITSELF.
+// LIST VALUES ARE YAML FLOW SEQUENCES SO THEY CAN BE INLINED AS-IS.
+var GalaxyDefaults = map[string]string{
+	"authors":       `["stuttgart-things"]`,
+	"description":   "ansible collection built by stuttgart-things",
+	"license":       `["Apache-2.0"]`,
+	"license_file":  "",
+	"tags":          "[]",
+	"repository":    "https://github.com/stuttgart-things/ansible",
+	"documentation": "https://github.com/stuttgart-things/ansible",
+	"homepage":      "https://github.com/stuttgart-things/ansible",
+	"issues":        "https://github.com/stuttgart-things/ansible/issues",
+}
+
+// BUILDS THE RENDER DATA FOR GalaxyConfig FROM THE PARSED COLLECTION META,
+// FALLING BACK TO GalaxyDefaults FOR EVERY FIELD THE COLLECTION LEAVES UNSET
+func BuildGalaxyMeta(meta map[string]string, version string) map[string]interface{} {
+	galaxyMeta := map[string]interface{}{
+		"namespace": meta["namespace"],
+		"name":      meta["name"],
+		"version":   version,
+	}
+
+	for field, fallback := range GalaxyDefaults {
+		if value := meta[field]; value != "" {
+			galaxyMeta[field] = value
+			continue
+		}
+		galaxyMeta[field] = fallback
+	}
+
+	return galaxyMeta
+}
 
 func GenerateSemanticVersion() string {
 	// GET THE CURRENT DATE AND TIME

--- a/ansible/collections/meta.go
+++ b/ansible/collections/meta.go
@@ -19,7 +19,7 @@ authors: {{ .authors }}
 ### OPTIONAL
 description: {{ .description }}
 license: {{ .license }}
-license_file: '{{ .license_file }}'
+license_file: {{ .license_file }}
 tags: {{ .tags }}
 dependencies: {}
 repository: {{ .repository }}
@@ -30,13 +30,13 @@ build_ignore: []
 `
 
 // FALLBACKS FOR GALAXY FIELDS A COLLECTION DOES NOT DECLARE ITSELF.
-// LIST VALUES ARE YAML FLOW SEQUENCES SO THEY CAN BE INLINED AS-IS.
-var GalaxyDefaults = map[string]string{
-	"authors":       `["stuttgart-things"]`,
+// HELD AS NATIVE GO VALUES AND ENCODED ON RENDER, LIKE THE DECLARED ONES.
+var GalaxyDefaults = map[string]interface{}{
+	"authors":       []string{"stuttgart-things"},
 	"description":   "ansible collection built by stuttgart-things",
-	"license":       `["Apache-2.0"]`,
+	"license":       []string{"Apache-2.0"},
 	"license_file":  "",
-	"tags":          "[]",
+	"tags":          []string{},
 	"repository":    "https://github.com/stuttgart-things/ansible",
 	"documentation": "https://github.com/stuttgart-things/ansible",
 	"homepage":      "https://github.com/stuttgart-things/ansible",
@@ -44,7 +44,9 @@ var GalaxyDefaults = map[string]string{
 }
 
 // BUILDS THE RENDER DATA FOR GalaxyConfig FROM THE PARSED COLLECTION META,
-// FALLING BACK TO GalaxyDefaults FOR EVERY FIELD THE COLLECTION LEAVES UNSET
+// FALLING BACK TO GalaxyDefaults FOR EVERY FIELD THE COLLECTION LEAVES UNSET.
+// OPTIONAL FIELDS ARE ENCODED YAML FRAGMENTS SO A COLON, '#' OR QUOTE IN A
+// VALUE CANNOT BREAK OR TRUNCATE THE RENDERED galaxy.yml
 func BuildGalaxyMeta(meta map[string]string, version string) map[string]interface{} {
 	galaxyMeta := map[string]interface{}{
 		"namespace": meta["namespace"],
@@ -53,11 +55,17 @@ func BuildGalaxyMeta(meta map[string]string, version string) map[string]interfac
 	}
 
 	for field, fallback := range GalaxyDefaults {
+		// meta HOLDS VALUES ALREADY ENCODED BY setMetaString/setMetaList
 		if value := meta[field]; value != "" {
 			galaxyMeta[field] = value
 			continue
 		}
-		galaxyMeta[field] = fallback
+
+		encoded, ok := encodeGalaxyValue(field, fallback)
+		if !ok {
+			continue
+		}
+		galaxyMeta[field] = encoded
 	}
 
 	return galaxyMeta

--- a/ansible/collections/meta_test.go
+++ b/ansible/collections/meta_test.go
@@ -1,0 +1,127 @@
+/*
+Copyright © 2026 Patrick Hermann patrick.hermann@sva.de
+*/
+
+package collections
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+type galaxyFile struct {
+	Namespace   string   `yaml:"namespace"`
+	Name        string   `yaml:"name"`
+	Version     string   `yaml:"version"`
+	Readme      string   `yaml:"readme"`
+	Authors     []string `yaml:"authors"`
+	Description string   `yaml:"description"`
+	License     []string `yaml:"license"`
+	LicenseFile string   `yaml:"license_file"`
+	Tags        []string `yaml:"tags"`
+	Repository  string   `yaml:"repository"`
+	Homepage    string   `yaml:"homepage"`
+	Issues      string   `yaml:"issues"`
+}
+
+// RENDERS GalaxyConfig FROM A collection.yaml AND PARSES THE RESULT BACK
+func renderGalaxy(t *testing.T, collectionFile string) galaxyFile {
+	t.Helper()
+
+	meta := map[string]string{}
+	empty := map[string]string{}
+
+	_, _, _, _, meta, _ = ProcessCollectionFile([]byte(collectionFile), empty, empty, empty, empty, meta, empty)
+
+	rendered := RenderTemplate(GalaxyConfig, BuildGalaxyMeta(meta, "26.4.379"))
+
+	var parsed galaxyFile
+	if err := yaml.Unmarshal([]byte(rendered), &parsed); err != nil {
+		t.Fatalf("rendered galaxy.yml is not valid YAML: %v\n---\n%s", err, rendered)
+	}
+
+	return parsed
+}
+
+// A COLLECTION THAT DECLARES NOTHING BUT name/namespace MUST NOT SHIP
+// PLACEHOLDER METADATA OR THE WRONG LICENSE
+func TestBuildGalaxyMetaAppliesDefaults(t *testing.T) {
+	parsed := renderGalaxy(t, `---
+name: baseos
+namespace: sthings
+`)
+
+	if parsed.Namespace != "sthings" || parsed.Name != "baseos" || parsed.Version != "26.4.379" {
+		t.Errorf("unexpected identity: %+v", parsed)
+	}
+
+	if len(parsed.License) != 1 || parsed.License[0] != "Apache-2.0" {
+		t.Errorf("license = %v, want [Apache-2.0]", parsed.License)
+	}
+
+	for _, author := range parsed.Authors {
+		if strings.Contains(author, "example.com") {
+			t.Errorf("placeholder author leaked: %q", author)
+		}
+	}
+
+	for field, value := range map[string]string{
+		"description": parsed.Description,
+		"repository":  parsed.Repository,
+		"homepage":    parsed.Homepage,
+		"issues":      parsed.Issues,
+	} {
+		if strings.Contains(value, "example.com") || strings.Contains(value, "your collection") {
+			t.Errorf("placeholder %s leaked: %q", field, value)
+		}
+	}
+}
+
+// VALUES DECLARED IN collection.yaml MUST WIN OVER THE DEFAULTS
+func TestBuildGalaxyMetaHonoursDeclaredValues(t *testing.T) {
+	parsed := renderGalaxy(t, `---
+name: container
+namespace: sthings
+description: container collection
+license:
+  - MIT
+tags:
+  - container
+  - k8s
+repository: https://github.com/stuttgart-things/ansible
+issues: https://github.com/stuttgart-things/ansible/issues
+`)
+
+	if len(parsed.License) != 1 || parsed.License[0] != "MIT" {
+		t.Errorf("license = %v, want [MIT]", parsed.License)
+	}
+
+	if parsed.Description != "container collection" {
+		t.Errorf("description = %q", parsed.Description)
+	}
+
+	if len(parsed.Tags) != 2 || parsed.Tags[0] != "container" || parsed.Tags[1] != "k8s" {
+		t.Errorf("tags = %v, want [container k8s]", parsed.Tags)
+	}
+}
+
+// REGRESSION: RENDERING RAN THROUGH html/template, WHICH ESCAPED THE QUOTES
+// AND ANGLE BRACKETS OF AN AUTHOR ENTRY INTO &#34; / &lt; AND BROKE THE YAML
+func TestRenderTemplateDoesNotHTMLEscape(t *testing.T) {
+	parsed := renderGalaxy(t, `---
+name: baseos
+namespace: sthings
+authors:
+  - patrick hermann <patrick.hermann@sva.de>
+`)
+
+	if len(parsed.Authors) != 1 {
+		t.Fatalf("authors = %v, want 1 entry", parsed.Authors)
+	}
+
+	if parsed.Authors[0] != "patrick hermann <patrick.hermann@sva.de>" {
+		t.Errorf("author was mangled: %q", parsed.Authors[0])
+	}
+}

--- a/ansible/collections/meta_test.go
+++ b/ansible/collections/meta_test.go
@@ -125,3 +125,79 @@ authors:
 		t.Errorf("author was mangled: %q", parsed.Authors[0])
 	}
 }
+
+// REGRESSION: SCALARS WERE INTERPOLATED RAW, SO A COLON BROKE THE YAML, A '#'
+// SILENTLY TRUNCATED THE VALUE AND A QUOTE ESCAPED license_file's WRAPPING
+func TestBuildGalaxyMetaQuotesScalars(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		declared    string
+		description string
+		licenseFile string
+	}{
+		{
+			name:        "colon",
+			declared:    "description: 'baseos: the linux collection'",
+			description: "baseos: the linux collection",
+		},
+		{
+			name:        "hash",
+			declared:    "description: 'roles #1 for linux'",
+			description: "roles #1 for linux",
+		},
+		{
+			name:        "quote",
+			declared:    `license_file: "it's.txt"`,
+			description: GalaxyDefaults["description"].(string),
+			licenseFile: "it's.txt",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			parsed := renderGalaxy(t, "---\nname: baseos\nnamespace: sthings\n"+tc.declared+"\n")
+
+			if parsed.Description != tc.description {
+				t.Errorf("description = %q, want %q", parsed.Description, tc.description)
+			}
+
+			if parsed.LicenseFile != tc.licenseFile {
+				t.Errorf("license_file = %q, want %q", parsed.LicenseFile, tc.licenseFile)
+			}
+		})
+	}
+}
+
+// REGRESSION: OPTIONAL FIELDS ARE ONLY WRITTEN WHEN DECLARED, SO A COLLECTION
+// THAT OMITS THEM USED TO INHERIT THE PREVIOUSLY PROCESSED COLLECTION'S VALUES
+// INSTEAD OF THE DEFAULTS — meta IS REUSED ACROSS FILES AND CALLS
+func TestProcessCollectionFileDoesNotLeakBetweenCollections(t *testing.T) {
+	empty := func() map[string]string { return map[string]string{} }
+	meta := map[string]string{}
+
+	declared := []byte("---\nname: container\nnamespace: sthings\ndescription: container collection\nlicense:\n  - MIT\ntags:\n  - k8s\n")
+	_, _, _, _, meta, _ = ProcessCollectionFile(declared, empty(), empty(), empty(), empty(), meta, empty())
+
+	bare := []byte("---\nname: baseos\nnamespace: sthings\n")
+	_, _, _, _, meta, _ = ProcessCollectionFile(bare, empty(), empty(), empty(), empty(), meta, empty())
+
+	var parsed galaxyFile
+	rendered := RenderTemplate(GalaxyConfig, BuildGalaxyMeta(meta, "26.4.379"))
+	if err := yaml.Unmarshal([]byte(rendered), &parsed); err != nil {
+		t.Fatalf("rendered galaxy.yml is not valid YAML: %v\n---\n%s", err, rendered)
+	}
+
+	if parsed.Name != "baseos" {
+		t.Fatalf("name = %q, want baseos", parsed.Name)
+	}
+
+	if parsed.Description != GalaxyDefaults["description"].(string) {
+		t.Errorf("description leaked from previous collection: %q", parsed.Description)
+	}
+
+	if len(parsed.License) != 1 || parsed.License[0] != "Apache-2.0" {
+		t.Errorf("license leaked from previous collection: %v", parsed.License)
+	}
+
+	if len(parsed.Tags) != 0 {
+		t.Errorf("tags leaked from previous collection: %v", parsed.Tags)
+	}
+}

--- a/ansible/collections/read.go
+++ b/ansible/collections/read.go
@@ -5,6 +5,7 @@ Copyright © 2024 Patrick Hermann patrick.hermann@sva.de
 package collections
 
 import (
+	"encoding/json"
 	"log"
 
 	"gopkg.in/yaml.v3"
@@ -28,9 +29,17 @@ type Config struct {
 		File string `yaml:"file"`
 	} `yaml:"modules"`
 	Meta struct {
-		Name      string `yaml:"name"`
-		Namespace string `yaml:"namespace"`
-		// Authors   []string `yaml:"authors"`
+		Name          string   `yaml:"name"`
+		Namespace     string   `yaml:"namespace"`
+		Authors       []string `yaml:"authors"`
+		Description   string   `yaml:"description"`
+		License       []string `yaml:"license"`
+		LicenseFile   string   `yaml:"license_file"`
+		Tags          []string `yaml:"tags"`
+		Repository    string   `yaml:"repository"`
+		Documentation string   `yaml:"documentation"`
+		Homepage      string   `yaml:"homepage"`
+		Issues        string   `yaml:"issues"`
 	} `yaml:",inline"` // Use inline to match top-level fields
 	Requirements string `yaml:"requirements"` // Field to capture requirements
 }
@@ -69,7 +78,17 @@ func ProcessCollectionFile(data []byte, playbooks, vars, modules, templates, met
 	if config.Meta.Name != "" && config.Meta.Namespace != "" {
 		meta["name"] = config.Meta.Name
 		meta["namespace"] = config.Meta.Namespace
-		// meta["authors"] = config.Meta.Authors[0]
+
+		// ONLY DECLARED FIELDS ARE SET SO GalaxyDefaults CAN FILL THE REST
+		setMetaString(meta, "description", config.Meta.Description)
+		setMetaString(meta, "license_file", config.Meta.LicenseFile)
+		setMetaString(meta, "repository", config.Meta.Repository)
+		setMetaString(meta, "documentation", config.Meta.Documentation)
+		setMetaString(meta, "homepage", config.Meta.Homepage)
+		setMetaString(meta, "issues", config.Meta.Issues)
+		setMetaList(meta, "authors", config.Meta.Authors)
+		setMetaList(meta, "license", config.Meta.License)
+		setMetaList(meta, "tags", config.Meta.Tags)
 	}
 
 	// ADD REQUIREMENTS TO THE REQUIREMENTS MAP
@@ -78,4 +97,28 @@ func ProcessCollectionFile(data []byte, playbooks, vars, modules, templates, met
 	}
 
 	return playbooks, vars, modules, templates, meta, requirements
+}
+
+// STORES A NON-EMPTY SCALAR ON THE META MAP
+func setMetaString(meta map[string]string, key, value string) {
+	if value == "" {
+		return
+	}
+	meta[key] = value
+}
+
+// STORES A NON-EMPTY LIST ON THE META MAP AS A YAML FLOW SEQUENCE.
+// JSON IS A SUBSET OF YAML 1.2, SO MARSHALLING HANDLES QUOTING/ESCAPING
+func setMetaList(meta map[string]string, key string, values []string) {
+	if len(values) == 0 {
+		return
+	}
+
+	encoded, err := json.Marshal(values)
+	if err != nil {
+		log.Printf("Error encoding %s %v: %v", key, values, err)
+		return
+	}
+
+	meta[key] = string(encoded)
 }

--- a/ansible/collections/read.go
+++ b/ansible/collections/read.go
@@ -5,8 +5,10 @@ Copyright © 2024 Patrick Hermann patrick.hermann@sva.de
 package collections
 
 import (
+	"bytes"
 	"encoding/json"
 	"log"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -79,6 +81,12 @@ func ProcessCollectionFile(data []byte, playbooks, vars, modules, templates, met
 		meta["name"] = config.Meta.Name
 		meta["namespace"] = config.Meta.Namespace
 
+		// meta IS REUSED ACROSS FILES AND CALLS, SO DROP THE PREVIOUS
+		// COLLECTION'S OPTIONAL FIELDS BEFORE THEY CAN LEAK INTO THIS ONE
+		for field := range GalaxyDefaults {
+			delete(meta, field)
+		}
+
 		// ONLY DECLARED FIELDS ARE SET SO GalaxyDefaults CAN FILL THE REST
 		setMetaString(meta, "description", config.Meta.Description)
 		setMetaString(meta, "license_file", config.Meta.LicenseFile)
@@ -99,26 +107,42 @@ func ProcessCollectionFile(data []byte, playbooks, vars, modules, templates, met
 	return playbooks, vars, modules, templates, meta, requirements
 }
 
+// ENCODES A GALAXY VALUE AS A YAML FLOW SCALAR OR SEQUENCE.
+// JSON IS A SUBSET OF YAML 1.2, SO MARSHALLING HANDLES QUOTING/ESCAPING.
+// HTML ESCAPING IS OFF SO AN AUTHOR'S <email> STAYS READABLE IN galaxy.yml
+func encodeGalaxyValue(key string, value interface{}) (string, bool) {
+	var buf bytes.Buffer
+
+	encoder := json.NewEncoder(&buf)
+	encoder.SetEscapeHTML(false)
+
+	if err := encoder.Encode(value); err != nil {
+		log.Printf("Error encoding %s %v: %v", key, value, err)
+		return "", false
+	}
+
+	// Encode APPENDS A NEWLINE THAT WOULD BREAK THE SINGLE-LINE TEMPLATE SLOT
+	return strings.TrimRight(buf.String(), "\n"), true
+}
+
 // STORES A NON-EMPTY SCALAR ON THE META MAP
 func setMetaString(meta map[string]string, key, value string) {
 	if value == "" {
 		return
 	}
-	meta[key] = value
+
+	if encoded, ok := encodeGalaxyValue(key, value); ok {
+		meta[key] = encoded
+	}
 }
 
-// STORES A NON-EMPTY LIST ON THE META MAP AS A YAML FLOW SEQUENCE.
-// JSON IS A SUBSET OF YAML 1.2, SO MARSHALLING HANDLES QUOTING/ESCAPING
+// STORES A NON-EMPTY LIST ON THE META MAP
 func setMetaList(meta map[string]string, key string, values []string) {
 	if len(values) == 0 {
 		return
 	}
 
-	encoded, err := json.Marshal(values)
-	if err != nil {
-		log.Printf("Error encoding %s %v: %v", key, values, err)
-		return
+	if encoded, ok := encodeGalaxyValue(key, values); ok {
+		meta[key] = encoded
 	}
-
-	meta[key] = string(encoded)
 }

--- a/ansible/collections/render.go
+++ b/ansible/collections/render.go
@@ -6,8 +6,8 @@ package collections
 
 import (
 	"bytes"
-	"html/template"
 	"log"
+	"text/template"
 )
 
 func RenderTemplate(templateData string, data map[string]interface{}) (renderTemplate string) {


### PR DESCRIPTION
## Problem

`GalaxyConfig` in `ansible/collections/meta.go` hardcoded every optional field, so **every** collection this module builds ships placeholder metadata:

```json
"authors":     ["your name <example@domain.com>"],
"description": "your collection description",
"license":     ["GPL-2.0-or-later"],
"repository":  "http://example.com/repository"
```

The license is the one that matters. `stuttgart-things/ansible` is **Apache-2.0**, so every artifact released from it for the past two years has declared **GPL-2.0-or-later** — a licensing misstatement shipped to every consumer, and a blocker for publishing to Galaxy (which rejects placeholder metadata).

Authors parsing was already commented out in `read.go`, so the `authors: [patrick.hermann]` that `collections/baseos/collection.yaml` has declared all along was silently dropped.

## Changes

- **`collections/meta.go`** — `GalaxyConfig` is now fully data-driven. Adds `GalaxyDefaults` (license defaults to `Apache-2.0`) and `BuildGalaxyMeta()`, which merges parsed collection meta over the defaults.
- **`collections/read.go`** — parses `authors`, `description`, `license`, `license_file`, `tags`, `repository`, `documentation`, `homepage` and `issues` from `collection.yaml`. Only non-empty values are set, so `GalaxyDefaults` fills the rest. List values are serialised as YAML flow sequences via `json.Marshal` (JSON is a subset of YAML 1.2, so quoting and escaping are handled correctly).
- **`collections/render.go`** — `html/template` → `text/template`.
- **`collections/meta_test.go`** — new tests.
- **`collection.go`** — uses `BuildGalaxyMeta()`.

### Why the `text/template` switch is part of this

`RenderTemplate` renders YAML but ran through `html/template`, which HTML-escapes. That had been harmless only because no data-dependent quoting ever reached the template. As soon as list values are injected it emits:

```yaml
license: [&#34;Apache-2.0&#34;]
```

Verified by reverting the import and re-running the tests. `TestRenderTemplateDoesNotHTMLEscape` covers it.

## Compatibility

Additive. Collections that declare none of the new keys keep building and simply pick up the defaults instead of the placeholders. Older module versions parsing a `collection.yaml` that *does* declare the new keys ignore them (yaml.v3 is lenient by default), so this does not have to land in lockstep with consumer repos.

## Verification

`go build ./...`, `go vet ./collections/` and `go test ./collections/` all pass. (`go vet ./...` reports a pre-existing `fmt.Println` formatting-directive warning in `pipeline.go`, untouched here.)

End to end with `run-collection-build-pipeline` against `stuttgart-things/ansible` `collections/baseos` — resulting `MANIFEST.json`:

```json
"namespace": "sthings",
"name": "baseos",
"authors": ["patrick.hermann"],
"tags": ["baseos", "linux", "setup"],
"description": "base operating system setup, users, binaries and filesystem management",
"license": ["Apache-2.0"],
"repository": "https://github.com/stuttgart-things/ansible",
"issues": "https://github.com/stuttgart-things/ansible/issues"
```

## Follow-up

Once released, `stuttgart-things/ansible` needs `DAGGER_ANSIBLE_MODULE_VERSION` bumped in `Taskfile.yaml` and both workflows (pinned at `v0.109.0` today), then a re-release of all four collections so the corrected license reaches consumers. Companion PR declaring the metadata there: stuttgart-things/ansible#1044. Context: stuttgart-things/ansible#1043.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDecVMyhtUtixsLmT4oLwY


---

## Follow-up commit: quote galaxy scalars and reset metadata per collection

Review of the above found two defects in it, both fixed in `e4a52f7`.

### 1. Unquoted scalar interpolation produced invalid `galaxy.yml`

List fields went through `json.Marshal`, but scalars were interpolated raw:

```yaml
description: {{ .description }}
license_file: '{{ .license_file }}'
```

| declared value | result |
| --- | --- |
| `description: 'baseos: the linux collection'` | invalid YAML — `mapping values are not allowed in this context` |
| `description: 'roles #1 for linux'` | silently truncated to `roles` |
| `license_file: "it's.txt"` | invalid YAML — the `'` closes the hand-written quote |

A colon or `#` in a description is entirely ordinary, so this was reachable in normal use.

Scalars now route through the same encoder as lists via a shared `encodeGalaxyValue`, `GalaxyDefaults` holds native Go values so declared and default values take identical paths, and the manual quotes are gone from the template. HTML escaping is disabled on the encoder so an author's `<email>` stays readable instead of rendering as `<email>`.

### 2. Optional metadata leaked between collections

Optional fields are only written when declared, and the `meta` map is a package-level global in `main.go` that is never reset. A collection omitting them inherited the *previously processed* collection's values rather than the defaults:

```
SECOND COLLECTION name=baseos description=container collection license=["MIT"]
```

This was new in this PR — previously only `name`/`namespace` were carried, and both were unconditionally overwritten. `ProcessCollectionFile` now deletes the `GalaxyDefaults` keys before repopulating; iterating `GalaxyDefaults` rather than a second hand-maintained list keeps the two from drifting.

### Verification

`gofmt`, `go build ./...`, `go vet ./collections/...` and `go test ./collections/...` all clean. Both new tests were confirmed non-vacuous by reverting each fix in isolation:

- without the leak fix → `description leaked from previous collection: "container collection"`
- without scalar quoting → `description = "roles", want "roles #1 for linux"`

Rendered output for a collection declaring an author, a colon-bearing description and tags:

```yaml
authors: ["patrick hermann <patrick.hermann@sva.de>"]
description: "baseos: linux base roles"
license: ["Apache-2.0"]
license_file: ""
tags: ["linux"]
```

### Not addressed

`meta`, `playbooks`, `vars`, `templates` and `modules` in `main.go:28-33` are package-level globals that are never reset, so the others still accumulate across `InitCollection` calls in a session. Pre-existing and a wider refactor than this PR.
