### PR TITLE
feat(ansible): accept a caller-supplied collection version

### DIFF
--- a/ansible/collection.go
+++ b/ansible/collection.go
@@ -31,7 +31,22 @@ func (m *Ansible) Build(
 // INIT ANSIBLE COLLECTION STRUCTURE
 func (m *Ansible) InitCollection(
 	ctx context.Context,
-	src *dagger.Directory) (*CollectionResult, error) {
+	src *dagger.Directory,
+	// Collection version. src is a plain directory with no git history, so a
+	// monotonic version has to be supplied by the caller. Falls back to a
+	// generated calendar version, which is NOT monotonic.
+	// +optional
+	version string,
+) (*CollectionResult, error) {
+
+	// SCOPED PER CALL. THESE WERE PACKAGE-LEVEL, SO BUILDING TWO COLLECTIONS IN
+	// ONE SESSION MERGED THE FIRST ONE'S CONTENT INTO THE SECOND ONE'S ARTIFACT
+	playbooks := make(map[string]string)
+	vars := make(map[string]string)
+	templates := make(map[string]string)
+	modules := make(map[string]string)
+	meta := make(map[string]string)
+	requirements := make(map[string]string)
 
 	allCollectionFiles, err := src.Entries(ctx)
 	if err != nil {
@@ -47,7 +62,12 @@ func (m *Ansible) InitCollection(
 		playbooks, vars, modules, templates, meta, requirements = collections.ProcessCollectionFile([]byte(content), playbooks, vars, modules, templates, meta, requirements)
 	}
 
-	metaInformation := collections.BuildGalaxyMeta(meta, collections.GenerateSemanticVersion())
+	if version == "" {
+		version = collections.GenerateSemanticVersion()
+		fmt.Println("NO VERSION SUPPLIED, GENERATED (NON-MONOTONIC):", version)
+	}
+
+	metaInformation := collections.BuildGalaxyMeta(meta, version)
 
 	collectionContentDir := collectionWorkDir + "/" + metaInformation["namespace"].(string) + "/" + metaInformation["name"].(string)
 

--- a/ansible/collections/read.go
+++ b/ansible/collections/read.go
@@ -81,8 +81,8 @@ func ProcessCollectionFile(data []byte, playbooks, vars, modules, templates, met
 		meta["name"] = config.Meta.Name
 		meta["namespace"] = config.Meta.Namespace
 
-		// meta IS REUSED ACROSS FILES AND CALLS, SO DROP THE PREVIOUS
-		// COLLECTION'S OPTIONAL FIELDS BEFORE THEY CAN LEAK INTO THIS ONE
+		// meta ACCUMULATES ACROSS THE FILES OF ONE COLLECTION, SO DROP ANY
+		// OPTIONAL FIELDS A PREVIOUS FILE SET BEFORE APPLYING THIS ONE'S
 		for field := range GalaxyDefaults {
 			delete(meta, field)
 		}

--- a/ansible/main.go
+++ b/ansible/main.go
@@ -26,12 +26,6 @@ import (
 )
 
 var (
-	playbooks         = make(map[string]string)
-	vars              = make(map[string]string)
-	templates         = make(map[string]string)
-	modules           = make(map[string]string)
-	meta              = make(map[string]string)
-	requirements      = make(map[string]string)
 	collectionWorkDir = "/collection"
 	workDir           = "/src"
 )

--- a/ansible/pipeline.go
+++ b/ansible/pipeline.go
@@ -15,10 +15,14 @@ func (m *Ansible) RunCollectionBuildPipeline(
 	// +optional
 	// +default="11.11.0"
 	ansibleVersion string,
+	// Collection version, passed through to InitCollection. Falls back to a
+	// generated calendar version, which is NOT monotonic.
+	// +optional
+	version string,
 ) (*dagger.Directory, error) {
 
 	// INIT COLLECTION
-	collection, err := m.InitCollection(ctx, src)
+	collection, err := m.InitCollection(ctx, src, version)
 	if err != nil {
 		fmt.Println("Failed to initialize collection: %v", err)
 	}


### PR DESCRIPTION
Addresses finding #1 of stuttgart-things/ansible#1043.

## Problem

`GenerateSemanticVersion` produces `YY.<weekday>.<minute-of-day>`:

```go
major := currentDate.Year() % 100
minor := int(currentDate.Weekday())      // 0 = Sunday .. 6 = Saturday
patch := currentDate.Hour()*60 + currentDate.Minute()
```

That is **not monotonic** — it drops every time the weekday resets, so a Sunday build sorts below the Saturday build before it.

Consequences already observed in `stuttgart-things/ansible`:

- Two pairs of distinct artifacts published under one version: `sthings-container-25.5.499` and `sthings-baseos-25.3.605`
- Its `requirements.yaml` pins had to be moved numerically *downward* (`26.3.1037` → `26.2.675`) to move *forward* in time

## Why the module cannot fix this alone

`InitCollection` receives a plain `*dagger.Directory` — `collections/<name>`, with no git history in it. Time is the only ordering signal available inside the module. A monotonic version has to be computed by the caller, where git exists, and passed in.

## Change

`InitCollection` and `RunCollectionBuildPipeline` take an optional `version`. When empty, the existing generator still runs — and now logs that it did:

```
NO VERSION SUPPLIED, GENERATED (NON-MONOTONIC): 26.2.753
```

The consuming workflow will pass `YY.MMDD.<git commit count>`, which is monotonic across day, month and year boundaries and greater than every version published so far.

## Also: package-level state leaked between collections

`playbooks`, `vars`, `templates`, `modules`, `meta` and `requirements` were **package-level maps**. Building two collections in one session merged the first one's playbooks, vars and templates into the second one's artifact — silently, producing a plausible-looking but wrong collection.

Only `meta` had been guarded, in #320. All six are now scoped per call, which also makes that guard's comment accurate.

Latent rather than active today, since each CI job is a separate `dagger call` building one collection — but this is the file that change touches.

## Verification

Against `stuttgart-things/ansible`:

| run | result |
|---|---|
| `--version 26.728.1151` on `collections/baseos` | `MANIFEST.json` version `26.728.1151`, artifact `sthings-baseos-26.728.1151.tar.gz` |
| no `--version` on `collections/rke` | builds, falls back to `26.2.753`, logs the warning |

`go build`, `go vet ./collections/` and `go test ./collections/` all pass.

## Compatibility

Additive and optional. Existing callers keep their current behaviour until they pass the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDecVMyhtUtixsLmT4oLwY