### PR TITLE
ci: drop dead asset globs from .releaserc

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -21,19 +21,11 @@
         "changelogFile": "CHANGELOG.md"
       }
     ],
-    [
-      "@semantic-release/github",
-      {
-        "assets": [
-          "dist/**/*.{go,mod,sum}",
-          "docs/**/*.{pdf,md}"
-        ]
-      }
-    ],
+    "@semantic-release/github",
     [
       "@semantic-release/git",
       {
-        "assets": ["CHANGELOG.md", "go.mod", "go.sum"],
+        "assets": ["CHANGELOG.md"],
         "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }
     ]


### PR DESCRIPTION
## What

Every release logged two warnings:

```
✘ The asset dist/**/*.{go,mod,sum} cannot be read, and will be ignored.
✘ The asset docs/**/*.{pdf,md} cannot be read, and will be ignored.
```

Neither `dist/` nor `docs/` exists in this repo. Modules are consumed by git ref (`github.com/stuttgart-things/dagger/<module>@<tag>`), not by release assets, so there's nothing to attach — I dropped the `assets` config from `@semantic-release/github` rather than pointing it somewhere new.

## The quieter one

`@semantic-release/git` had the same problem without the warning: its `assets` listed `go.mod` and `go.sum`, which **don't exist at the repo root either** — each module carries its own.

```
$ for p in dist docs go.mod go.sum CHANGELOG.md; do ... done
dist           MISSING
docs           MISSING
go.mod         MISSING
go.sum         MISSING
CHANGELOG.md   EXISTS
```

They silently matched nothing, which is why `v0.123.0`'s release commit touched only `CHANGELOG.md` and the plugin reported `Found 1 file(s) to commit`. Narrowed to what actually exists.

## Risk

None — both globs already resolved to nothing, so the published output is byte-identical. This only removes misleading warnings and stops the config implying artifacts that are never published.

Verified `semantic-release --dry-run` still loads all 11 plugins. `ci:` prefix, so no release is cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YUHNVfwo2mTTupe8vFVjaW