### PR TITLE
feat(crossplane): CLI v2.4.1 plus gepinntes Core-Binary statt Docker-Container

### DIFF
--- a/.github/workflows/this-test-modules.yaml
+++ b/.github/workflows/this-test-modules.yaml
@@ -140,5 +140,5 @@ jobs:
       # secrets (SOPS_AGE_KEY, registry creds) unavailable here. Add a module
       # once tests/smoke/<module>.sh exists and runs without secrets.
       - name: smoke test ${{ matrix.module }}
-        if: contains(fromJSON('["ansible", "terraform"]'), matrix.module)
+        if: contains(fromJSON('["ansible", "crossplane", "terraform"]'), matrix.module)
         run: ./tests/smoke/${{ matrix.module }}.sh

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -564,6 +564,11 @@ tasks:
     vars:
       MODULE: oci
 
+  test-crossplane-smoke:
+    desc: Smoke-test the crossplane container (no secrets needed; this is what CI runs)
+    cmds:
+      - ./tests/smoke/crossplane.sh
+
   test-crossplane:
     desc: Test crossplane functions
     cmds:

--- a/crossplane/container.go
+++ b/crossplane/container.go
@@ -11,103 +11,141 @@ const (
 	// script and binary evolve together.
 	openapi2jsonschemaURL = "https://raw.githubusercontent.com/yannh/kubeconform/" + kubeconformVersion + "/scripts/openapi2jsonschema.py"
 
-	// crossplaneChannel selects the crossplane (crank) CLI release channel.
-	// Used only as the bucket path and as the fallback when crossplaneVersion
-	// is empty.
+	// crossplaneChannel selects the release channel. Used as the bucket path
+	// for BOTH downloads below.
 	crossplaneChannel = "stable"
 
-	// crossplaneVersion pins the crank CLI to an exact release instead of
-	// tracking the channel's floating `current` marker.
+	// ZWEI BINAERIES, ZWEI BUCKETS, ZWEI REPOS. Das ist der Kern hier.
 	//
-	// Why this is pinned: crank v2.3.0 changed `crossplane render` to run the
-	// pipeline by re-exec'ing `crossplane internal render` inside the function
-	// Docker container. The crossplane-contrib function images still ship an
-	// older crossplane binary that has no `internal` subcommand, so every
-	// render fails with:
+	// Seit CLI v2.3.0 sind CLI und Core GETRENNT:
 	//
-	//   cannot run crossplane internal render in Docker: container exited with
-	//   status 1: crossplane: error: unexpected argument internal
+	//   CLI   crossplane/cli          cli.crossplane.io        `crossplane`
+	//         kann render/resource trace/xpkg
+	//   Core  crossplane/crossplane   releases.crossplane.io   `crossplane`
+	//         kann `internal render` — die CLI kann das NICHT
 	//
-	// When `current` advanced to v2.3.0 this silently broke Verify for every
-	// function-based Configuration (it tracked the channel, so the same module
-	// tag started failing without any code change). v2.2.2 is the latest
-	// release whose render still runs functions the compatible way. Bump this
-	// once the function images (or a later crank) resolve the skew.
-	// See stuttgart-things/dagger#295.
-	crossplaneVersion = "v2.2.2"
+	// Vor v2.3.0 lagen beide zusammen und die CLI hiess im alten Bucket
+	// `crank`. Deshalb ergibt ein reiner Versions-Bump ohne Bucket- und
+	// Namenswechsel einen 404.
+	//
+	// WARUM DER CORE UEBERHAUPT GEBRAUCHT WIRD.
+	//
+	// Ab CLI v2.3.0 fuehrt `crossplane render` die Pipeline nicht mehr selbst
+	// aus, sondern ruft `crossplane internal render` auf — per Default in
+	// einem Docker-Container aus dem FLOATING Tag
+	// xpkg.crossplane.io/crossplane/crossplane:stable. Beides ist hier falsch:
+	//
+	//   1. Floating Tag. Genau so ist Verify im Juni ohne eine einzige
+	//      Code-Aenderung umgefallen (#295), damals ueber den CLI-Kanal.
+	//   2. Docker im Sandbox. Verschachteltes Docker funktioniert in diesem
+	//      Modul nicht — deshalb laufen die Functions seit #300 als
+	//      Dagger-Services. Ein Core-CONTAINER wuerde genau das zurueckholen.
+	//
+	// Gemessen (2026-08-21): die Development-Runtime schuetzt NICHT davor —
+	// auch mit allen Functions als Services startet die CLI den Core-Container.
+	//
+	// Loesung: den Core als BINARY mitinstallieren und render per
+	// --crossplane-binary darauf zeigen lassen. Damit entfaellt der Container
+	// vollstaendig und der Tag ist gepinnt statt floating.
+	//
+	// crossplaneVersion pinnt die CLI, crossplaneCoreVersion den Core. Beide
+	// exakt, nie ein floating `current`.
+	crossplaneVersion     = "v2.4.1"
+	crossplaneCoreVersion = "v2.4.0"
 )
 
-// crossplaneInstall downloads and installs the crossplane (crank) CLI with
-// integrity checks. A bare `curl … --output crossplane` silently writes
-// whatever the CDN returns — a truncated stream, a rate-limit page, or an
-// HTML 4xx body — to /usr/bin/crossplane, which then executes as a shell
-// script and dies with "line 2: syntax error: unexpected newline" (the
-// classic "no ELF magic, fall back to /bin/sh" signature). This installer
-// instead: (1) uses curl -f + --retry so HTTP errors and transient blips
-// fail/retry rather than producing a bad file; (2) verifies the published
-// SHA256 when present (catches truncation and HTML-200 bodies); (3) executes
-// the installed binary as a final sanity gate; and (4) retries the whole
-// install on any failure, so a single corrupt fetch can't poison the image.
+// crossplaneInstall downloads and installs BOTH binaries the render path
+// needs — the CLI (/usr/bin/crossplane) and the Crossplane core
+// (/usr/bin/crossplane-core, which owns `internal render`). See the constants
+// above for why these are two artifacts from two buckets.
+//
+// Integrity, and why the two are treated differently. A bare
+// `curl … --output crossplane` silently writes whatever the CDN returns — a
+// truncated stream, a rate-limit page, an HTML 4xx body — to a file that then
+// executes as a shell script and dies with "line 2: syntax error: unexpected
+// newline" (the "no ELF magic, fall back to /bin/sh" signature). So every
+// download here uses curl -f + --retry, is checksum-checked where the bucket
+// publishes a usable checksum, is executed as a final gate, and is retried as
+// a whole on any failure.
+//
+//	core  STRICT   releases.crossplane.io publishes a matching sha256
+//	              (verified 2026-08-21: dfe07a50… published == served).
+//	CLI   WARN     cli.crossplane.io publishes a sha256 that does NOT match
+//	              the served binary — and not through CDN mangling: the
+//	              checksum shipped INSIDE the official bundle tarball
+//	              (ad0661ee…) disagrees with the binary next to it in the same
+//	              tarball (963ae072…). Measured 2026-08-21, same symptom the
+//	              old crank.sha256 had (#295). A mismatch is therefore a
+//	              WARNING and the run-check is the authoritative gate: a
+//	              truncated or HTML body cannot execute, so it still fails and
+//	              retries; only a valid binary with a wrong published checksum
+//	              is allowed through.
 const crossplaneInstall = `#!/bin/sh
 set -u
 
 CHANNEL="${CROSSPLANE_CHANNEL:-stable}"
-BASE="https://releases.crossplane.io/${CHANNEL}"
+CLI_VERSION="${CROSSPLANE_VERSION:?CROSSPLANE_VERSION must be set}"
+CORE_VERSION="${CROSSPLANE_CORE_VERSION:?CROSSPLANE_CORE_VERSION must be set}"
 
-# Prefer an explicit pin (CROSSPLANE_VERSION). Only fall back to the channel's
-# floating 'current' marker when no pin is set — tracking 'current' is what let
-# crank v2.3.0 silently break render (see crossplaneVersion comment above).
-VERSION="${CROSSPLANE_VERSION:-}"
-if [ -z "${VERSION}" ]; then
-  # Resolve the channel to an exact version so the binary and its checksum are
-  # fetched from the same immutable path.
-  VERSION=$(curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors "${BASE}/current/version" | tr -d '[:space:]')
+# Bucket and binary name follow the CLI version, exactly as the upstream
+# cli.crossplane.io/install.sh does: v2.3.0 is where the CLI moved to its own
+# repo and bucket and lost the "crank" name. Encoded here rather than hardcoded
+# so pinning CROSSPLANE_VERSION back to a 2.2.x release keeps working.
+_v=$(echo "${CLI_VERSION}" | sed -e 's/^v//' -e 's/-.*//')
+_maj=$(echo "${_v}" | cut -d. -f1)
+_min=$(echo "${_v}" | cut -d. -f2)
+if [ "${_maj}" -lt 2 ] || { [ "${_maj}" -eq 2 ] && [ "${_min}" -lt 3 ]; }; then
+  CLI_URL="https://releases.crossplane.io/${CHANNEL}/${CLI_VERSION}/bin/linux_amd64/crank"
+else
+  CLI_URL="https://cli.crossplane.io/${CHANNEL}/${CLI_VERSION}/bin/linux_amd64/crossplane"
 fi
-if [ -z "${VERSION}" ]; then
-  echo "crossplane install: could not resolve ${CHANNEL} version" >&2
-  exit 1
-fi
-URL="${BASE}/${VERSION}/bin/linux_amd64/crank"
-echo "crossplane install: ${CHANNEL} ${VERSION}"
+CORE_URL="https://releases.crossplane.io/${CHANNEL}/${CORE_VERSION}/bin/linux_amd64/crossplane"
 
-i=1
-while [ "${i}" -le 3 ]; do
-  rm -f /tmp/crossplane /tmp/crossplane.sha256
-  if curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors "${URL}" -o /tmp/crossplane; then
-    # Integrity: compare against the published checksum when the bucket serves
-    # one. NOTE: the crossplane release bucket currently serves crank.sha256
-    # files that do NOT match the served binaries (observed for every version
-    # via CloudFront, 2026-06). A mismatch is therefore treated as a WARNING,
-    # not a hard failure: we fall through to the run-check below, which is the
-    # authoritative gate. A truncated body or HTML error page cannot execute,
-    # so it still fails the run-check and retries; only a valid binary with a
-    # stale/wrong published checksum is allowed through.
-    # See stuttgart-things/dagger#295.
-    if curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors "${URL}.sha256" -o /tmp/crossplane.sha256 2>/dev/null \
-         && [ -s /tmp/crossplane.sha256 ]; then
-      want=$(awk '{print $1}' /tmp/crossplane.sha256)
-      got=$(sha256sum /tmp/crossplane | awk '{print $1}')
-      if [ "${want}" != "${got}" ]; then
-        echo "crossplane install: WARNING checksum mismatch (want ${want}, got ${got}); relying on run-check" >&2
+# fetch_install <url> <dest> <strict|warn> <run-check command...>
+fetch_install() {
+  _url="$1"; _dest="$2"; _mode="$3"; shift 3
+  _i=1
+  while [ "${_i}" -le 3 ]; do
+    rm -f /tmp/dl /tmp/dl.sha256
+    if curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors "${_url}" -o /tmp/dl; then
+      if curl -fsSL --retry 3 --retry-delay 2 "${_url}.sha256" -o /tmp/dl.sha256 2>/dev/null \
+           && [ -s /tmp/dl.sha256 ]; then
+        _want=$(awk '{print $1}' /tmp/dl.sha256)
+        _got=$(sha256sum /tmp/dl | awk '{print $1}')
+        if [ "${_want}" != "${_got}" ]; then
+          if [ "${_mode}" = "strict" ]; then
+            echo "install ${_dest}: checksum MISMATCH (want ${_want}, got ${_got})" >&2
+            _i=$((_i + 1)); sleep 2; continue
+          fi
+          echo "install ${_dest}: WARNING checksum mismatch (want ${_want}, got ${_got}); relying on run-check" >&2
+        fi
       fi
+      install -m 0755 /tmp/dl "${_dest}"
+      if "$@" >/dev/null 2>&1; then
+        echo "install ${_dest}: ok"
+        return 0
+      fi
+      echo "install ${_dest}: installed binary failed to run, attempt ${_i}" >&2
+    else
+      echo "install ${_dest}: download failed, attempt ${_i}" >&2
     fi
-    install -m 0755 /tmp/crossplane /usr/bin/crossplane
-    # Authoritative gate: a real binary runs; an HTML/truncated/corrupt file
-    # does not. This also covers the case where the bucket served no .sha256
-    # (or a wrong one) to verify.
-    if crossplane version --client >/dev/null 2>&1; then
-      echo "crossplane install: ok"
-      exit 0
-    fi
-    echo "crossplane install: installed binary failed to run, attempt ${i}" >&2
-  else
-    echo "crossplane install: download failed, attempt ${i}" >&2
-  fi
-  i=$((i + 1)); sleep 2
-done
+    _i=$((_i + 1)); sleep 2
+  done
+  echo "install ${_dest}: failed after retries" >&2
+  return 1
+}
 
-echo "crossplane install: failed after retries" >&2
-exit 1
+echo "crossplane install: CLI ${CHANNEL} ${CLI_VERSION} from ${CLI_URL}"
+fetch_install "${CLI_URL}" /usr/bin/crossplane warn /usr/bin/crossplane version --client || exit 1
+
+# The run-check is deliberately "internal render --help": that subcommand is the
+# ONLY reason this binary is here, and it is exactly what the CLI cannot do. A
+# core image/binary without it would otherwise install cleanly and fail later,
+# per XR, with "unexpected argument internal".
+echo "crossplane install: core ${CHANNEL} ${CORE_VERSION} from ${CORE_URL}"
+fetch_install "${CORE_URL}" /usr/bin/crossplane-core strict /usr/bin/crossplane-core internal render --help || exit 1
+
+exit 0
 `
 
 // GetXplaneContainer returns the default image for Crossplane with crossplane and kcl2xrd installed
@@ -122,6 +160,7 @@ func (m *Crossplane) GetXplaneContainer(ctx context.Context) *dagger.Container {
 		// then dies as a "line 2: syntax error" the next time it is invoked.
 		WithEnvVariable("CROSSPLANE_CHANNEL", crossplaneChannel).
 		WithEnvVariable("CROSSPLANE_VERSION", crossplaneVersion).
+		WithEnvVariable("CROSSPLANE_CORE_VERSION", crossplaneCoreVersion).
 		WithNewFile("/tmp/install-crossplane.sh", crossplaneInstall).
 		WithExec([]string{"sh", "/tmp/install-crossplane.sh"}).
 		// Install kcl2xrd

--- a/crossplane/container.go
+++ b/crossplane/container.go
@@ -68,8 +68,14 @@ const (
 // publishes a usable checksum, is executed as a final gate, and is retried as
 // a whole on any failure.
 //
-//	core  STRICT   releases.crossplane.io publishes a matching sha256
-//	              (verified 2026-08-21: dfe07a50… published == served).
+//	core  STRICT   releases.crossplane.io publishes a matching sha256 for the
+//	              pinned release (verified 2026-08-21: dfe07a50… published ==
+//	              served). NOTE: older core releases do NOT verify — v2.2.2
+//	              serves df012171… while publishing 336aabd0…, so pinning
+//	              crossplaneCoreVersion back below v2.3 makes this install
+//	              refuse with a checksum error. That is the right outcome for
+//	              the wrong-looking reason: those cores have no `internal
+//	              render` either, so they could never serve this purpose.
 //	CLI   WARN     cli.crossplane.io publishes a sha256 that does NOT match
 //	              the served binary — and not through CDN mangling: the
 //	              checksum shipped INSIDE the official bundle tarball

--- a/crossplane/verify.go
+++ b/crossplane/verify.go
@@ -251,6 +251,25 @@ fi
 # can't work inside this sandbox (#300). Rewrite functions.yaml so every Function
 # uses the "Development" runtime targeting its service endpoint; render then
 # dials the already-running service instead of launching a container.
+# ---- Render ohne Core-Container (Layer 0.7) ------------------------------
+# Ab CLI v2.3.0 ruft render "crossplane internal render" auf und startet dafuer
+# per Default einen Docker-Container aus dem floating Tag
+# xpkg.crossplane.io/crossplane/crossplane:stable. Beides ist hier falsch:
+# verschachteltes Docker geht in diesem Sandbox nicht (#300, der Grund fuer die
+# Development-Runtime unten), und ein floating Tag im Ausfuehrungspfad ist genau
+# das, was Verify im Juni umgeworfen hat (#295).
+#
+# Gemessen (2026-08-21): die Development-Runtime allein hilft NICHT — auch mit
+# allen Functions als Services startet die CLI den Core-Container.
+#
+# /usr/bin/crossplane-core ist der gepinnte Core (siehe container.go). Geprueft
+# wird auf das FLAG, nicht auf die Version: eine aeltere CROSSPLANE_VERSION
+# rendert in-process und kennt --crossplane-binary nicht.
+CORE_ARGS=""
+if crossplane render --help 2>&1 | grep -q -- '--crossplane-binary' && [ -x /usr/bin/crossplane-core ]; then
+  CORE_ARGS="--crossplane-binary=/usr/bin/crossplane-core"
+fi
+
 FUNCTIONS_FILE=examples/functions.yaml
 if [ -f examples/functions.yaml ]; then
   if yq ea 'with(select(.kind == "Function");
@@ -286,7 +305,7 @@ for xr in examples/xr*.yaml; do
   # Render the Composition. ${FUNCTIONS_FILE} is the Development-runtime rewrite
   # of examples/functions.yaml (falls back to the original if the rewrite was a
   # no-op). ${EXTRA_ARGS} (unquoted, may be empty) supplies EnvironmentConfigs.
-  if RENDERED=$(crossplane render "${xr}" apis/composition.yaml "${FUNCTIONS_FILE}" ${EXTRA_ARGS} 2>/tmp/render.err); then
+  if RENDERED=$(crossplane render "${xr}" apis/composition.yaml "${FUNCTIONS_FILE}" ${EXTRA_ARGS} ${CORE_ARGS} 2>/tmp/render.err); then
     status="${status}, render-ok"
 
     # Layer 2: Object wrapper

--- a/tests/smoke/crossplane.sh
+++ b/tests/smoke/crossplane.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Smoke test for the crossplane module.
+#
+# WHY THIS EXISTS. The module's CI (this-test-modules.yaml) runs `dagger
+# functions`, `dagger develop` and golangci-lint — all of which pass whether or
+# not the container can actually be built and whether or not the binaries
+# inside it work. Everything this module does at runtime hinges on two
+# downloads, and both of them changed under us:
+#
+#   - the CLI moved repo + bucket + binary name at v2.3.0 (crank -> crossplane,
+#     releases.crossplane.io -> cli.crossplane.io), so a version bump alone
+#     yields a 404;
+#   - render needs a SECOND binary, the Crossplane core, because CLI >= v2.3.0
+#     shells out to `crossplane internal render` — which the CLI itself cannot
+#     do (see container.go).
+#
+# None of that is visible to a compile-time check. This script builds the real
+# container and asserts the four properties verify.go depends on.
+#
+# Runs without secrets, which is what makes it CI-eligible (unlike
+# `task test-crossplane`, which pushes to a registry).
+#
+# Kept as a script rather than inline Taskfile cmds so CI can run it without
+# Task, whose remote `includes:` needs an interactive trust prompt.
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+MODULE=crossplane
+
+# EXPECTED VERSIONS ARE READ FROM container.go SO THE PINS STAY SINGLE-SOURCED.
+# A bump there without a matching bump here would otherwise pass silently.
+read_pin() {
+  sed -n "s/.*$1 *= *\"\(.*\)\".*/\1/p" "${MODULE}/container.go" | head -1
+}
+cli_want=$(read_pin crossplaneVersion)
+core_want=$(read_pin crossplaneCoreVersion)
+
+for pair in "crossplaneVersion:${cli_want}" "crossplaneCoreVersion:${core_want}"; do
+  if [ -z "${pair#*:}" ]; then
+    echo "FAIL: could not read ${pair%%:*} from ${MODULE}/container.go"
+    exit 1
+  fi
+done
+echo "pins from container.go: CLI ${cli_want}, core ${core_want}"
+
+# One container build, one exec: cheaper than four round trips, and it keeps
+# the assertions below reading against a single captured output.
+# NOTE: dagger parses --args as CSV, so the probe below must contain neither a
+# comma nor a double quote — both terminate the field and produce
+# "bare \" in non-quoted-field". Hence `grep -o -- --crossplane-binary` with the
+# pattern unquoted after `--` rather than the more obvious quoted form.
+probe='crossplane version --client; crossplane-core --version; crossplane-core internal render --help 2>&1 | head -1; crossplane render --help 2>&1 | grep -o -- --crossplane-binary | head -1'
+
+out=$(dagger call -m "./${MODULE}" get-xplane-container \
+  with-exec --args sh,-c,"${probe}" \
+  stdout)
+echo "${out}"
+
+fail=0
+assert() { # assert <needle> <description>
+  if echo "${out}" | grep -qF -- "$1"; then
+    echo "OK: $2"
+  else
+    echo "FAIL: $2 (missing: $1)"
+    fail=1
+  fi
+}
+
+assert "Client Version: ${cli_want}" "CLI is ${cli_want}"
+assert "${core_want}" "core binary is ${core_want}"
+# The core's whole reason for being installed. Without it every render dies
+# per-XR with "unexpected argument internal".
+assert "crossplane internal render" "core provides 'internal render'"
+# verify.go probes for this flag and silently renders without it if absent —
+# which would put the floating crossplane:stable container back in the path.
+assert "--crossplane-binary" "CLI supports --crossplane-binary"
+
+exit "${fail}"


### PR DESCRIPTION
Hebt den `crank`-Pin von **v2.2.2** an und macht den Render-Pfad dabei container-frei. Beides gehoert zusammen — einzeln funktioniert keines von beidem.

Schritt 1 aus stuttgart-things/crossplane-configurations#349.

## Zwei Binaeries, zwei Buckets, zwei Repos

Seit CLI v2.3.0 sind CLI und Core getrennt:

| | Repo | Bucket | Binary |
|---|---|---|---|
| **CLI** (`render`, `resource trace`, `xpkg`) | `crossplane/cli` | `cli.crossplane.io` | `crossplane` |
| **Core** (`internal render`) | `crossplane/crossplane` | `releases.crossplane.io` | `crossplane` |

Vorher lagen beide zusammen und die CLI hiess im alten Bucket `crank`. Ein reiner Versions-Bump ohne Bucket- und Namenswechsel ergibt einen **404** — deshalb stand dieser Pin so lange.

## Warum der Core dazukommt

Ab CLI v2.3.0 rendert die CLI nicht mehr selbst, sondern ruft `crossplane internal render` auf — per Default in einem Docker-Container aus dem **floating** Tag `xpkg.crossplane.io/crossplane/crossplane:stable`. Beides ist hier falsch:

1. **Floating Tag im Ausfuehrungspfad.** Genau so ist Verify im Juni ohne eine einzige Code-Aenderung umgefallen (#295), damals ueber den CLI-Kanal.
2. **Verschachteltes Docker.** Geht in diesem Sandbox nicht — deshalb laufen die Functions seit #300 als Dagger-Services. Ein Core-Container wuerde genau das zurueckholen.

### Gemessen, nicht angenommen

Die naheliegende Hoffnung — „die Development-Runtime umgeht das schon" — traegt **nicht**:

```
DEBUG Starting development runtime {"function": "function-go-templating"}
DEBUG Starting development runtime {"function": "function-auto-ready"}
DEBUG Running crossplane internal render in Docker
      {"image": "xpkg.crossplane.io/crossplane/crossplane:stable"}
crossplane: error: unexpected argument internal
```

Auch mit **allen** Functions als Services startet die CLI den Core-Container.

`internal render` steckt im **Core**, nicht in der CLI — `--crossplane-binary` auf die CLI selbst scheitert deshalb ebenso. Mit dem Core-Binary laeuft der Render durch, ohne dass ein Container startet.

## Integritaet: einmal strikt, einmal warnend

| | Modus | Grund |
|---|---|---|
| core | **STRICT** | `releases.crossplane.io` veroeffentlicht eine passende sha256 (`dfe07a50…` published == served) |
| CLI | **WARN** | `cli.crossplane.io` veroeffentlicht eine sha256, die **nicht** zum Binary passt |

Und zwar nicht durch CDN-Mangeln: die Pruefsumme **im offiziellen Bundle-Tarball** (`ad0661ee…`) widerspricht dem Binary daneben **im selben Tarball** (`963ae072…`). Dasselbe Symptom wie beim alten `crank.sha256` (#295).

Der Run-Check bleibt die autoritative Instanz. Fuer den Core ist er bewusst `internal render --help` — genau das ist der einzige Grund, warum das Binary da ist, und genau das kann die CLI nicht.

## Rueckwaertskompatibel

Bucket und Binaername werden aus der CLI-Version **abgeleitet** (Grenze v2.3.0, wie in `cli.crossplane.io/install.sh`), nicht hardcodiert. Ein Pin zurueck auf 2.2.x funktioniert weiter. `verify.go` prueft auf das **Flag** statt auf die Version, aus demselben Grund.

## Getestet in echtem `cgr.dev/chainguard/wolfi-base`

```
CROSSPLANE_VERSION=v2.4.1  ->  cli.crossplane.io/.../crossplane
  install /usr/bin/crossplane: WARNING checksum mismatch …; relying on run-check
  install /usr/bin/crossplane: ok
  install /usr/bin/crossplane-core: ok          <- strikt, keine Warnung
  crossplane version --client            -> v2.4.1
  crossplane-core internal render --help -> vorhanden

CROSSPLANE_VERSION=v2.2.2  ->  releases.crossplane.io/.../crank
  crossplane version --client            -> v2.2.2
```

`go build`, `go vet`, `gofmt` sauber.

## Danach

Erst nach einem Release hiervon kann `crossplane-configurations` `CROSSPLANE_MODULE_VERSION` nachziehen — zusammen mit 106 neuen Goldens (gemessen: deterministisch ueber zwei vollstaendige Laeufe, rein additiv, und die Objektnamen entsprechen erstmals denen im echten Cluster).

Refs stuttgart-things/crossplane-configurations#349, #295, #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0196ZK3n9XHuWxhx9es8bcTi