### PR TITLE
feat(ansible): pass extra environment into the container as secrets

### DIFF
--- a/ansible/execute.go
+++ b/ansible/execute.go
@@ -22,6 +22,7 @@ func (m *Ansible) executePlaybooks(
 	vaultUrl *dagger.Secret,
 	sshUser *dagger.Secret,
 	sshPassword *dagger.Secret, // pragma: allowlist secret
+	envSecrets *dagger.Secret,
 	ansibleVersion string,
 ) (*dagger.Container, error) {
 
@@ -48,6 +49,37 @@ func (m *Ansible) executePlaybooks(
 	}
 	if sshPassword != nil { // pragma: allowlist secret
 		ansible = ansible.WithSecretVariable("ANSIBLE_PASSWORD", sshPassword)
+	}
+
+	// Caller-supplied environment. Playbooks that resolve values with
+	// lookup('env', ...) read them on the controller -- this container -- not on
+	// the target, so they have to be set here.
+	//
+	// This takes one dotenv-formatted secret rather than a list of secrets
+	// because a []Secret parameter cannot be passed from the dagger CLI: even a
+	// well-formed env://NAME is rejected with "malformed secret config at index
+	// 0", while the same URI works for a scalar Secret.
+	if envSecrets != nil {
+		dotenv, err := envSecrets.Plaintext(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read env secrets: %w", err)
+		}
+
+		for i, line := range strings.Split(dotenv, "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" || strings.HasPrefix(line, "#") {
+				continue
+			}
+
+			name, value, found := strings.Cut(line, "=")
+			name = strings.TrimSpace(name)
+			if !found || name == "" {
+				return nil, fmt.Errorf("env secrets line %d is not NAME=value", i+1)
+			}
+
+			// Re-wrap as its own secret so the value stays masked downstream.
+			ansible = ansible.WithSecretVariable(name, dag.SetSecret(name, value))
+		}
 	}
 
 	// MOUNT AND INSTALL REQUIREMENTS
@@ -127,12 +159,20 @@ func (m *Ansible) Execute(
 	sshUser *dagger.Secret,
 	// +optional
 	sshPassword *dagger.Secret,
+	// Extra environment variables for the Ansible container, as a secret in
+	// dotenv format (NAME=value per line, # comments and blanks ignored). For
+	// playbooks that resolve values with lookup('env', ...), which is evaluated
+	// on the controller, not on the target. Each entry is re-wrapped as its own
+	// secret, so values stay masked in logs.
+	// Example: --env-secrets env:ANSIBLE_ENV
+	// +optional
+	envSecrets *dagger.Secret,
 	// The Ansible version, defaults to defaultAnsibleVersion
 	// +optional
 	ansibleVersion string,
 ) (bool, error) {
 
-	_, err := m.executePlaybooks(ctx, src, playbooks, requirements, inventory, parameters, vaultAppRoleID, vaultSecretID, vaultUrl, sshUser, sshPassword, ansibleVersion)
+	_, err := m.executePlaybooks(ctx, src, playbooks, requirements, inventory, parameters, vaultAppRoleID, vaultSecretID, vaultUrl, sshUser, sshPassword, envSecrets, ansibleVersion)
 	if err != nil {
 		return false, err
 	}
@@ -165,12 +205,20 @@ func (m *Ansible) ExecuteAndExport(
 	sshUser *dagger.Secret,
 	// +optional
 	sshPassword *dagger.Secret,
+	// Extra environment variables for the Ansible container, as a secret in
+	// dotenv format (NAME=value per line, # comments and blanks ignored). For
+	// playbooks that resolve values with lookup('env', ...), which is evaluated
+	// on the controller, not on the target. Each entry is re-wrapped as its own
+	// secret, so values stay masked in logs.
+	// Example: --env-secrets env:ANSIBLE_ENV
+	// +optional
+	envSecrets *dagger.Secret,
 	// The Ansible version, defaults to defaultAnsibleVersion
 	// +optional
 	ansibleVersion string,
 ) (*dagger.Directory, error) {
 
-	ctr, err := m.executePlaybooks(ctx, src, playbooks, requirements, inventory, parameters, vaultAppRoleID, vaultSecretID, vaultUrl, sshUser, sshPassword, ansibleVersion)
+	ctr, err := m.executePlaybooks(ctx, src, playbooks, requirements, inventory, parameters, vaultAppRoleID, vaultSecretID, vaultUrl, sshUser, sshPassword, envSecrets, ansibleVersion)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Warum

Playbooks, die Werte per `lookup('env', 'NAME')` auflösen, lesen sie auf dem **Controller** — also im Container des Moduls — nicht auf dem Ziel. `sthings.container.kind_machinery` macht genau das:

```yaml
sops_age_key:   {{ lookup('env', 'SOPS_AGE_KEY') }}
sops_git_token: {{ lookup('env', 'SOPS_GIT_TOKEN') }}
```

Bisher gab es keinen Weg, die hineinzubekommen: der Container erhielt nur `ANSIBLE_USER`, `ANSIBLE_PASSWORD`, `ANSIBLE_HOST_KEY_CHECKING` und die `VAULT_*` aus dem vault-Modul. Solche Playbooks scheitern also an ihren Preflight-Asserts.

## Was neu ist

`--env-secrets` an `execute` und `execute-and-export`: **ein** Secret im dotenv-Format.

```bash
export ANSIBLE_ENV="SOPS_AGE_KEY=$SOPS_AGE_KEY
SOPS_GIT_TOKEN=$SOPS_GIT_TOKEN"

dagger call -m ./ansible execute \
  --playbooks sthings.container.kind_machinery_profile \
  --env-secrets env:ANSIBLE_ENV \
  ...
```

Leerzeilen, `#`-Kommentare und umgebende Leerzeichen werden ignoriert. Jeder Eintrag wird per `dag.SetSecret` unter seinem eigenen Namen neu verpackt — die Werte bleiben in den Logs maskiert, statt wie bei `--parameters` in der `ansible-playbook`-Kommandozeile zu landen.

## Warum kein `[]Secret`

Das wäre die naheliegende Signatur, ist aber aus der Dagger-CLI in v0.21.8 **nicht ansprechbar**. Getestet, alle scheitern:

| Form | Ergebnis |
|---|---|
| `--env-secrets env://NAME` | `malformed secret config at index 0` |
| `--env-secrets env:NAME` | `malformed secret config at index 0` |
| Flag wiederholt | `malformed secret config at index 0` |
| komma-separiert | `malformed secret config at index 0` |
| `'["env://NAME"]'` | `unsupported secret provider: "[env"` |
| `NAME=env://NAME` | `unsupported secret provider` |

Dieselbe URI funktioniert bei einem **skalaren** `Secret` (`--ssh-user env:ANSIBLE_USER` läuft ja produktiv). Der Grund steht als Kommentar im Code, damit das niemand erneut durchprobiert.

## Verifiziert

- Beide Variablen lösen im Container auf, mit korrekten Längen (53 bzw. 37 Zeichen), `ok=2 failed=0`.
- **Kein Leck:** das komplette Run-Log nach beiden Klartextwerten durchsucht → 0 Treffer.
- Kaputte Zeile → `env secrets line 2 is not NAME=value`.
- Kommentare/Leerzeilen/Einrückung → ignoriert.
- Ohne das Flag: Verhalten unverändert (rückwärtskompatibel).
- `tests/smoke/ansible.sh` grün, `golangci-lint` 0 issues, keine Flag-Kollision.

## Danach

Für den eigentlichen Anwendungsfall fehlt noch die Durchreichung im `vm`-Modul (blueprints), das `--hosts` in ein Inventory übersetzt. Ohne das muss man dem ansible-Modul ein Inventory-File selbst mitgeben.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YUHNVfwo2mTTupe8vFVjaW