### PR TITLE
feat(ansible): install the kubernetes python library in the container

### DIFF
--- a/ansible/container.go
+++ b/ansible/container.go
@@ -59,7 +59,13 @@ func (m *Ansible) container(
 		"ansible==" + version,
 		"hvac",
 		"passlib",
-		"jmespath"})
+		"jmespath",
+		// Runtime dependency of the kubernetes.core collection, which ships with
+		// ansible but is unusable without it: every module fails with "Failed to
+		// import the required Python library (kubernetes)". Needed by playbooks
+		// like sthings.container.kind_secrets that talk to a cluster through
+		// kubernetes.core rather than kubectl.
+		"kubernetes"})
 
 	// Create ansible.cfg with proper settings
 	ctr = ctr.WithNewFile("/etc/ansible/ansible.cfg", `[defaults]


### PR DESCRIPTION
## Das Problem

Die Collection `kubernetes.core` wird mit ansible ausgeliefert, ist ohne ihre Laufzeit-Abhängigkeit aber unbenutzbar — jedes Modul scheitert sofort:

```
Failed to import the required Python library (kubernetes)
on dagger's Python /usr/bin/python3.13
```

Damit fielen alle Playbooks aus, die über `kubernetes.core` mit einem Cluster reden statt `kubectl` aufzurufen. Der Anlassfall ist `sthings.container.kind_secrets`, das genau so geschrieben ist, damit es *„auf dem Standard-Image läuft, das kein kubectl, helm oder kustomize hat"* — im Dagger-Container scheiterte es trotzdem.

## Die Änderung

`kubernetes` zur pip-Installation hinzugefügt (löst aktuell auf 36.0.3 auf).

## Verifiziert — gegen einen echten Cluster

`sthings.container.kind_secrets` per FQCN durch dieses Modul gefahren, gegen einen Wegwerf-kind-Cluster, mit `SOPS_AGE_KEY` und `KUBECONFIG_B64` über `--env-secrets`:

```
ok=8    changed=3    unreachable=0    failed=0
```

**Gegengeprüft von der Cluster-Seite**, nicht anhand der Debug-Ausgabe des Playbooks:

```
$ kubectl -n sops-secrets-operator-system get secret sops-age-key
sops-age-key   Opaque   1   14s
```

und der Wert von `age.agekey` dekodiert **byte-genau** zu dem, was übergeben wurde.

**Kein Leck:** weder der Age-Key noch `client-key-data` aus der kubeconfig taucht irgendwo im Run-Log auf (je 0 Treffer).

**Idempotenz:** ein zweiter echter Lauf meldet `changed=1`. Die verbleibende Änderung ist das Schreiben der kubeconfig-Datei — strukturell, weil jeder Lauf einen frischen Container bekommt. Beide Cluster-Operationen (Namespace, Secret) sind idempotent.

Der Cache hätte den zweiten Lauf übrigens verschluckt (12× CACHED), er wurde gezielt umgangen.

Smoke-Test grün, `golangci-lint` 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YUHNVfwo2mTTupe8vFVjaW