### PR TITLE
feat: add idempotent reserve-ip and https support to clusterbook module

### DIFF
--- a/clusterbook/README.md
+++ b/clusterbook/README.md
@@ -2,7 +2,16 @@
 
 Thin Dagger wrapper around the [clusterbook](https://github.com/stuttgart-things/clusterbook) HTTP API for managing cluster IP allocations. Use it from CI to query networks, allocate IPs to a cluster, and release them on teardown.
 
-All functions take `--server <host:port>` (HTTP) and return the raw JSON response from the server.
+All functions take `--server` and return the raw JSON response from the server.
+
+`--server` accepts either a bare `host:port` (assumed `http://`, the historical
+behaviour) or a full URL. Pass `--insecure` **before** the function name when the
+server is behind a certificate signed by an internal CA:
+
+```bash
+dagger call -m clusterbook --insecure list-networks \
+  --server https://clusterbook.infra.sthings-vsphere.labul.sva.de
+```
 
 ## Functions
 
@@ -24,7 +33,8 @@ All functions take `--server <host:port>` (HTTP) and return the raw JSON respons
 ### IPs
 | Function | Purpose |
 |----------|---------|
-| `assign-ip` | Assign an IP to a cluster (`PENDING` or `ASSIGNED`), optionally creating a DNS record. |
+| `assign-ip` | Assign a **specific** IP to a cluster (`PENDING` or `ASSIGNED`), optionally creating a DNS record. |
+| `reserve-ip` | Allocate the **next free** IP to a cluster, optionally creating its wildcard DNS record. Idempotent. |
 | `release-ip` | Release an IP back to the pool. |
 | `add-ips` | Add IPs to an existing network. |
 | `delete-ip` | Remove an IP from a network. |
@@ -66,3 +76,27 @@ dagger call -m clusterbook list-networks --server $CB
 dagger call -m clusterbook get-network-ips --server $CB --network-key 10.31.103
 dagger call -m clusterbook get-cluster --server $CB --cluster-name sthings-app-4
 ```
+
+## reserve-ip
+
+Picks the next free address in a pool and, with `--create-dns`, has clusterbook
+write the wildcard `*.{cluster}.{zone}` for it — IPAM and DNS in one call.
+
+```bash
+dagger call -m clusterbook --insecure reserve-ip \
+  --server https://clusterbook.infra.sthings-vsphere.labul.sva.de \
+  --network-key 10.31.104 \
+  --cluster my-cluster \
+  --create-dns
+# → {"cluster":"my-cluster","digit":"15","ip":"10.31.104.15","reused":false,"status":"ASSIGNED:DNS"}
+```
+
+**It is idempotent, and that is the point.** The bare `POST /reserve` endpoint
+hands out a *new* address on every call, so a pipeline retry silently leaks an
+IP and a second DNS record — with nothing anywhere reporting a failure.
+`reserve-ip` first asks whether the cluster already holds an address in that
+network and returns it if so, marked `"reused": true`. Both paths return the
+same five keys, so a caller never has to know which one ran.
+
+Use `assign-ip` instead when the address is already decided; use `reserve-ip`
+when clusterbook should decide.

--- a/clusterbook/clusters.go
+++ b/clusterbook/clusters.go
@@ -11,7 +11,7 @@ func (c *Clusterbook) ListClusters(
 	// clusterbook server address (e.g. "localhost:8080")
 	server string,
 ) (string, error) {
-	return doGet(ctx, server, "/api/v1/clusters")
+	return c.doGet(ctx, server, "/api/v1/clusters")
 }
 
 // GetCluster returns all IPs assigned to a specific cluster
@@ -22,5 +22,5 @@ func (c *Clusterbook) GetCluster(
 	// cluster name
 	clusterName string,
 ) (string, error) {
-	return doGet(ctx, server, fmt.Sprintf("/api/v1/clusters/%s", clusterName))
+	return c.doGet(ctx, server, fmt.Sprintf("/api/v1/clusters/%s", clusterName))
 }

--- a/clusterbook/ips.go
+++ b/clusterbook/ips.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"strings"
 )
 
 // AssignIP assigns an IP address to a cluster
@@ -28,7 +30,7 @@ func (c *Clusterbook) AssignIP(
 		"status":     status,
 		"create_dns": createDns,
 	}
-	return doPost(ctx, server, fmt.Sprintf("/api/v1/networks/%s/assign", networkKey), body)
+	return c.doPost(ctx, server, fmt.Sprintf("/api/v1/networks/%s/assign", networkKey), body)
 }
 
 // ReleaseIP releases an IP address back to the available pool
@@ -44,7 +46,7 @@ func (c *Clusterbook) ReleaseIP(
 	body := map[string]interface{}{
 		"ip": ip,
 	}
-	return doPost(ctx, server, fmt.Sprintf("/api/v1/networks/%s/release", networkKey), body)
+	return c.doPost(ctx, server, fmt.Sprintf("/api/v1/networks/%s/release", networkKey), body)
 }
 
 // AddIPs adds IPs to an existing network
@@ -60,7 +62,7 @@ func (c *Clusterbook) AddIPs(
 	body := map[string]interface{}{
 		"ips": ips,
 	}
-	return doPost(ctx, server, fmt.Sprintf("/api/v1/networks/%s/ips/add", networkKey), body)
+	return c.doPost(ctx, server, fmt.Sprintf("/api/v1/networks/%s/ips/add", networkKey), body)
 }
 
 // DeleteIP removes an IP from a network
@@ -73,5 +75,126 @@ func (c *Clusterbook) DeleteIP(
 	// last-octet IP to delete (e.g. "5")
 	ip string,
 ) (string, error) {
-	return doDelete(ctx, server, fmt.Sprintf("/api/v1/networks/%s/ips/%s", networkKey, ip))
+	return c.doDelete(ctx, server, fmt.Sprintf("/api/v1/networks/%s/ips/%s", networkKey, ip))
+}
+
+// ReserveIP allocates the next free IP in a network to a cluster, optionally
+// creating the wildcard DNS record for it.
+//
+// IDEMPOTENT ON PURPOSE. A plain POST /reserve hands out a NEW address every
+// time it is called, so a pipeline retry silently leaks an IP and a second DNS
+// record -- and neither shows up as a failure anywhere. This first asks whether
+// the cluster already holds an address in this network and returns that one if
+// so, which makes re-running a bake safe.
+//
+// The reply always has the same shape, reused telling the two paths apart:
+//
+//	{"ip":"10.31.103.6","digit":"6","status":"ASSIGNED:DNS","cluster":"c","reused":false}
+func (c *Clusterbook) ReserveIP(
+	ctx context.Context,
+	// clusterbook server address ("host:port" for http, or a full https:// URL)
+	server string,
+	// network key (e.g. "10.31.103")
+	networkKey string,
+	// cluster name -- also the label of the wildcard record, *.{cluster}.{zone}
+	cluster string,
+	// status to record
+	// +optional
+	// +default="ASSIGNED"
+	status string,
+	// create the wildcard DNS record for this assignment
+	// +optional
+	createDns bool,
+	// TTL in seconds after which the assignment is reclaimed (0 = permanent)
+	// +optional
+	leaseDurationSeconds int,
+) (string, error) {
+	if cluster == "" {
+		return "", fmt.Errorf("cluster is required")
+	}
+
+	if existing, err := c.lookupClusterIP(ctx, server, networkKey, cluster); err != nil {
+		return "", err
+	} else if existing != "" {
+		return existing, nil
+	}
+
+	body := map[string]interface{}{
+		"cluster":    cluster,
+		"status":     status,
+		"create_dns": createDns,
+	}
+	if leaseDurationSeconds > 0 {
+		body["lease_duration_seconds"] = leaseDurationSeconds
+	}
+
+	raw, err := c.doPost(ctx, server, fmt.Sprintf("/api/v1/networks/%s/reserve", networkKey), body)
+	if err != nil {
+		return "", err
+	}
+
+	var reserved struct {
+		IP      string `json:"ip"`
+		Digit   string `json:"digit"`
+		Status  string `json:"status"`
+		Cluster string `json:"cluster"`
+	}
+	if err := json.Unmarshal([]byte(raw), &reserved); err != nil {
+		return "", fmt.Errorf("reserve returned unparsable body %q: %w", raw, err)
+	}
+
+	// Rebuilt rather than passed through: the reserve endpoint also returns an
+	// "ips" array that the reuse path has no equivalent for, and a reply whose
+	// keys depend on which branch ran is exactly the kind of difference a
+	// caller only discovers on the rare path.
+	return marshalReservation(reserved.IP, reserved.Digit, reserved.Status, cluster, false)
+}
+
+// lookupClusterIP returns a reserve-shaped reply if the cluster already holds
+// an IP in networkKey, or "" if it holds none.
+func (c *Clusterbook) lookupClusterIP(ctx context.Context, server, networkKey, cluster string) (string, error) {
+	raw, found, err := c.doGetAllowMissing(ctx, server, "/api/v1/clusters/"+cluster)
+	if err != nil || !found {
+		return "", err
+	}
+
+	var info struct {
+		IPs []struct {
+			Network string `json:"network"`
+			IP      string `json:"ip"`
+			Status  string `json:"status"`
+		} `json:"ips"`
+	}
+	if err := json.Unmarshal([]byte(raw), &info); err != nil {
+		return "", fmt.Errorf("cluster info returned unparsable body %q: %w", raw, err)
+	}
+
+	for _, ip := range info.IPs {
+		if ip.Network != networkKey {
+			continue
+		}
+		digit := ip.IP
+		if i := strings.LastIndex(digit, "."); i >= 0 {
+			digit = digit[i+1:]
+		}
+		return marshalReservation(ip.IP, digit, ip.Status, cluster, true)
+	}
+
+	return "", nil
+}
+
+// marshalReservation is the single reply shape ReserveIP returns, whichever
+// path produced it.
+func marshalReservation(ip, digit, status, cluster string, reused bool) (string, error) {
+	out, err := json.Marshal(map[string]interface{}{
+		"ip":      ip,
+		"digit":   digit,
+		"status":  status,
+		"cluster": cluster,
+		"reused":  reused,
+	})
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
 }

--- a/clusterbook/main.go
+++ b/clusterbook/main.go
@@ -1,4 +1,37 @@
 package main
 
+import (
+	"crypto/tls"
+	"net/http"
+)
+
 type Clusterbook struct {
+	// Skip TLS verification when talking to an https clusterbook.
+	Insecure bool
+}
+
+// New builds the module.
+//
+// insecure exists because the deployed clusterbook sits behind a Gateway whose
+// certificate is signed by the internal Vault PKI: curl on a lab machine
+// accepts it, the Dagger container does not, and the failure reads
+// "certificate signed by unknown authority" rather than anything about trust
+// stores. Callers on plain http are unaffected.
+func New(
+	// skip TLS verification (internal CA)
+	// +optional
+	insecure bool,
+) *Clusterbook {
+	return &Clusterbook{Insecure: insecure}
+}
+
+func (c *Clusterbook) httpClient() *http.Client {
+	if !c.Insecure {
+		return http.DefaultClient
+	}
+	return &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, // #nosec G402 -- opt-in, internal CA
+		},
+	}
 }

--- a/clusterbook/networks.go
+++ b/clusterbook/networks.go
@@ -189,7 +189,7 @@ func (c *Clusterbook) doGetAllowMissing(ctx context.Context, server, path string
 	if err != nil {
 		return "", false, fmt.Errorf("failed to send request: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	raw, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/clusterbook/networks.go
+++ b/clusterbook/networks.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 )
 
 // ListNetworks returns all network pools with their stats
@@ -15,7 +16,7 @@ func (c *Clusterbook) ListNetworks(
 	// clusterbook server address (e.g. "localhost:8080")
 	server string,
 ) (string, error) {
-	return doGet(ctx, server, "/api/v1/networks")
+	return c.doGet(ctx, server, "/api/v1/networks")
 }
 
 // GetNetworkIPs returns all IPs in a network with their status and cluster info
@@ -26,7 +27,7 @@ func (c *Clusterbook) GetNetworkIPs(
 	// network key (e.g. "10.31.103")
 	networkKey string,
 ) (string, error) {
-	return doGet(ctx, server, fmt.Sprintf("/api/v1/networks/%s/ips", networkKey))
+	return c.doGet(ctx, server, fmt.Sprintf("/api/v1/networks/%s/ips", networkKey))
 }
 
 // CreateNetwork creates a new network with a flat list of IPs
@@ -43,7 +44,7 @@ func (c *Clusterbook) CreateNetwork(
 		"network": network,
 		"ips":     ips,
 	}
-	return doPost(ctx, server, "/api/v1/networks", body)
+	return c.doPost(ctx, server, "/api/v1/networks", body)
 }
 
 // CreateNetworkFromCidr creates a new network from CIDR notation
@@ -63,7 +64,7 @@ func (c *Clusterbook) CreateNetworkFromCidr(
 	if len(reserved) > 0 {
 		body["reserved"] = reserved
 	}
-	return doPost(ctx, server, "/api/v1/networks/cidr", body)
+	return c.doPost(ctx, server, "/api/v1/networks/cidr", body)
 }
 
 // DeleteNetwork deletes a network pool
@@ -74,18 +75,18 @@ func (c *Clusterbook) DeleteNetwork(
 	// network key (e.g. "10.31.103")
 	networkKey string,
 ) (string, error) {
-	return doDelete(ctx, server, fmt.Sprintf("/api/v1/networks/%s", networkKey))
+	return c.doDelete(ctx, server, fmt.Sprintf("/api/v1/networks/%s", networkKey))
 }
 
-func doGet(ctx context.Context, server, path string) (string, error) {
-	url := fmt.Sprintf("http://%s%s", server, path)
+func (c *Clusterbook) doGet(ctx context.Context, server, path string) (string, error) {
+	url := baseURL(server) + path
 
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
 		return "", fmt.Errorf("failed to create request: %w", err)
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := c.httpClient().Do(req)
 	if err != nil {
 		return "", fmt.Errorf("failed to send request: %w", err)
 	}
@@ -103,8 +104,8 @@ func doGet(ctx context.Context, server, path string) (string, error) {
 	return string(body), nil
 }
 
-func doPost(ctx context.Context, server, path string, payload interface{}) (string, error) {
-	url := fmt.Sprintf("http://%s%s", server, path)
+func (c *Clusterbook) doPost(ctx context.Context, server, path string, payload interface{}) (string, error) {
+	url := baseURL(server) + path
 
 	jsonData, err := json.Marshal(payload)
 	if err != nil {
@@ -117,7 +118,7 @@ func doPost(ctx context.Context, server, path string, payload interface{}) (stri
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := c.httpClient().Do(req)
 	if err != nil {
 		return "", fmt.Errorf("failed to send request: %w", err)
 	}
@@ -135,15 +136,15 @@ func doPost(ctx context.Context, server, path string, payload interface{}) (stri
 	return string(body), nil
 }
 
-func doDelete(ctx context.Context, server, path string) (string, error) {
-	url := fmt.Sprintf("http://%s%s", server, path)
+func (c *Clusterbook) doDelete(ctx context.Context, server, path string) (string, error) {
+	url := baseURL(server) + path
 
 	req, err := http.NewRequestWithContext(ctx, "DELETE", url, nil)
 	if err != nil {
 		return "", fmt.Errorf("failed to create request: %w", err)
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := c.httpClient().Do(req)
 	if err != nil {
 		return "", fmt.Errorf("failed to send request: %w", err)
 	}
@@ -159,4 +160,48 @@ func doDelete(ctx context.Context, server, path string) (string, error) {
 	}
 
 	return string(body), nil
+}
+
+// baseURL turns a server argument into a URL prefix.
+//
+// A bare "host:port" keeps the historical http:// default, so every existing
+// caller behaves exactly as before. Anything already carrying a scheme is used
+// verbatim -- the deployed clusterbook sits behind a Gateway on https, and
+// hardcoding http:// there produced a connection error that read like the
+// service was down.
+func baseURL(server string) string {
+	server = strings.TrimSuffix(server, "/")
+	if strings.HasPrefix(server, "http://") || strings.HasPrefix(server, "https://") {
+		return server
+	}
+	return "http://" + server
+}
+
+// doGetAllowMissing is doGet that reports a 404 instead of turning it into an
+// error, for endpoints where "not there yet" is a normal answer.
+func (c *Clusterbook) doGetAllowMissing(ctx context.Context, server, path string) (body string, found bool, err error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", baseURL(server)+path, nil)
+	if err != nil {
+		return "", false, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := c.httpClient().Do(req)
+	if err != nil {
+		return "", false, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", false, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode == http.StatusNotFound {
+		return "", false, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", false, fmt.Errorf("unexpected status: %d - %s", resp.StatusCode, raw)
+	}
+
+	return string(raw), true, nil
 }


### PR DESCRIPTION
Adds `reserve-ip` to the clusterbook module, plus the two things needed to actually reach the deployed server.

## reserve-ip

Allocates the next free address in a pool and, with `--create-dns`, has clusterbook write the wildcard `*.{cluster}.{zone}` for it — IPAM and DNS in one call.

**Idempotent on purpose.** The bare `POST /reserve` endpoint hands out a *new* address every time, so a pipeline retry leaks an IP and a second DNS record while every step still reports success. `reserve-ip` first asks whether the cluster already holds an address in that network and returns it marked `"reused": true`. Both paths return the same five keys.

## Supporting changes

- `--server` accepts a full URL. It hardcoded `http://`, so the deployed clusterbook (behind a Gateway on https) was unreachable and reported it as a connection error. A bare `host:port` still defaults to http — existing callers unaffected.
- `--insecure` skips TLS verification, for the internal Vault PKI certificate the Dagger container has no trust anchor for. Without it the error reads `certificate signed by unknown authority`.

## Verified against the live LabUL clusterbook

| check | result |
|---|---|
| reserve for an already-assigned cluster | returned its existing IP, `reused: true`, pool unchanged (5 assigned before **and** after) |
| fresh reserve | took exactly one address (11 free → 10) |
| second reserve, same cluster | same IP, `reused: true`, no second allocation |
| release | pool back to 11 free, cluster gone from the listing |

DNS was deliberately left out of the smoke test — clusterbook's own pdns path is already proven by the existing records; what needed proving was this module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EYkrt9hhBe7ei2d6v3Wudv